### PR TITLE
[Feature] Step 1 - 비밀번호 입력 화면 UI

### DIFF
--- a/presentation/src/main/java/com/knocklock/presentation/ui/password/NumberKeyboard.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/ui/password/NumberKeyboard.kt
@@ -1,12 +1,9 @@
-@file:OptIn(ExperimentalFoundationApi::class)
-
 package com.knocklock.presentation.ui.password
 
 import androidx.annotation.DrawableRes
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateIntSizeAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -122,12 +119,8 @@ fun KeyboardImageButton(
     }
 }
 
-/**
- * @param _emptyButton: 현재는 사용하지 않지만 통일성과 확장성을 위해 전달
- */
 @Composable
 fun KeyboardEmptyButton(
-    _emptyButton: KeyboardButtonType.Empty,
     modifier: Modifier = Modifier
 ) {
     Spacer(modifier = modifier.size(buttonWidth, buttonHeight))
@@ -189,7 +182,7 @@ fun NumberKeyboard(
                     )
                 }
                 is KeyboardButtonType.Empty -> {
-                    KeyboardEmptyButton(_emptyButton = type)
+                    KeyboardEmptyButton()
                 }
             }
         }

--- a/presentation/src/main/java/com/knocklock/presentation/ui/password/NumberKeyboard.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/ui/password/NumberKeyboard.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -165,7 +166,7 @@ fun NumberKeyboard(
 
     LazyVerticalGrid(
         columns = GridCells.Fixed(3),
-        modifier = modifier.fillMaxSize()
+        modifier = modifier.fillMaxWidth()
     ) {
         items(buttons) { type ->
             when (type) {

--- a/presentation/src/main/java/com/knocklock/presentation/ui/password/PasswordInputField.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/ui/password/PasswordInputField.kt
@@ -1,0 +1,97 @@
+package com.knocklock.presentation.ui.password
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Divider
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.knocklock.presentation.ui.theme.KnockLockTheme
+
+@Composable
+fun PasswordInputField(
+    modifier: Modifier = Modifier,
+    number: String
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = 8.dp),
+        horizontalAlignment = CenterHorizontally
+    ) {
+        Text(
+            text = number,
+            fontWeight = FontWeight.Bold,
+            fontSize = 16.sp
+        )
+
+        Divider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp, bottom = 8.dp)
+                .height(1.dp),
+            color = LocalContentColor.current
+        )
+    }
+}
+
+@Composable
+fun PasswordInputFieldLayout(
+    modifier: Modifier = Modifier,
+    password: String,
+    maxPasswordLength: Int = 6
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        for (index in 0..maxPasswordLength) {
+            val number = password.getOrNull(index)?.toString() ?: ""
+            key(index, number) {
+                PasswordInputField(
+                    number = number,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+    }
+}
+
+@Preview("DarkMode", uiMode = UI_MODE_NIGHT_YES)
+@Preview
+@Composable
+fun PasswordInputFieldPrev() {
+    KnockLockTheme {
+        Surface(color = MaterialTheme.colorScheme.primary) {
+            PasswordInputField(
+                number = "0"
+            )
+        }
+    }
+}
+
+@Preview("DarkMode", uiMode = UI_MODE_NIGHT_YES)
+@Preview
+@Composable
+fun PasswordInputFieldLayoutPrev() {
+    KnockLockTheme {
+        Surface(color = MaterialTheme.colorScheme.primary) {
+            PasswordInputFieldLayout(
+                password = "123"
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/knocklock/presentation/ui/password/PasswordInputScreen.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/ui/password/PasswordInputScreen.kt
@@ -1,0 +1,67 @@
+package com.knocklock.presentation.ui.password
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.knocklock.presentation.ui.theme.KnockLockTheme
+
+@Composable
+fun PasswordInputScreen(
+    inputtedPassword: String,
+    modifier: Modifier = Modifier
+) {
+    Box(modifier = modifier) {
+        PasswordInputFieldLayout(
+            modifier = Modifier.fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(top = 48.dp),
+            password = inputtedPassword
+        )
+
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .clip(
+                    MaterialTheme.shapes.extraLarge.copy(
+                        bottomEnd = CornerSize(0.dp), bottomStart = CornerSize(0.dp)
+                    )
+                ),
+            color = Color.White
+        ) {
+            CompositionLocalProvider(LocalContentColor.provides(Color.Black)) {
+                NumberKeyboard(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 40.dp)
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PasswordInputScreenPrev() {
+    KnockLockTheme {
+        Surface(color = MaterialTheme.colorScheme.primary) {
+            PasswordInputScreen(
+                inputtedPassword = "",
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 🔥 관련 이슈

## 🔥 PR Point

- 비밀번호 입력 화면 UI
   - 카드 기반의 키보드 레이아웃
   - 입력 필드 UI

### color는 theme만 따라가게 설정했어요!

## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|키보드 입력 화면|<img src="https://user-images.githubusercontent.com/33657541/207648115-fdb793cb-7cbf-45e6-b359-40edf16e4b52.png">|
