### PR TITLE
[Feature] Home 화면 UI

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.MainActivity" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.MainActivity" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_200</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>
@@ -10,7 +10,8 @@
         <item name="colorSecondaryVariant">@color/teal_200</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">false</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.MainActivity" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.MainActivity" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>
@@ -10,7 +10,8 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">true</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <application>
         <activity
             android:name=".MainActivity"
-            android:theme="@style/Theme.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <application>
         <activity
             android:name=".MainActivity"
+            android:theme="@style/Theme.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/presentation/src/main/java/com/knocklock/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/MainActivity.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
@@ -27,7 +28,6 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
-    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -36,14 +36,11 @@ class MainActivity : ComponentActivity() {
         setContent {
             KnockLockTheme {
                 val navController = rememberNavController()
-                Scaffold { paddingValues ->
-                    KnockLockNavHost(
-                        modifier = Modifier
-                            .padding(paddingValues)
-                            .systemBarsPadding(),
-                        navController = navController
-                    )
-                }
+                KnockLockNavHost(
+                    modifier = Modifier
+                        .fillMaxSize(),
+                    navController = navController
+                )
             }
         }
     }

--- a/presentation/src/main/java/com/knocklock/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/MainActivity.kt
@@ -7,10 +7,7 @@ import android.os.Bundle
 import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
@@ -37,8 +34,7 @@ class MainActivity : ComponentActivity() {
             KnockLockTheme {
                 val navController = rememberNavController()
                 KnockLockNavHost(
-                    modifier = Modifier
-                        .fillMaxSize(),
+                    modifier = Modifier.fillMaxSize(),
                     navController = navController
                 )
             }

--- a/presentation/src/main/java/com/knocklock/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/MainActivity.kt
@@ -7,12 +7,14 @@ import android.os.Bundle
 import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.view.WindowCompat
 import androidx.navigation.compose.rememberNavController
 import com.gun0912.tedpermission.PermissionListener
 import com.gun0912.tedpermission.normal.TedPermission
@@ -28,7 +30,7 @@ class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         requestPermission()
 
         setContent {
@@ -37,7 +39,8 @@ class MainActivity : ComponentActivity() {
                 Scaffold { paddingValues ->
                     KnockLockNavHost(
                         modifier = Modifier
-                            .padding(paddingValues),
+                            .padding(paddingValues)
+                            .systemBarsPadding(),
                         navController = navController
                     )
                 }

--- a/presentation/src/main/java/com/knocklock/presentation/home/HomeRoute.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/home/HomeRoute.kt
@@ -1,0 +1,14 @@
+package com.knocklock.presentation.home
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun HomeRoute(
+    modifier: Modifier = Modifier
+) {
+    Box(modifier = modifier) {
+
+    }
+}

--- a/presentation/src/main/java/com/knocklock/presentation/home/HomeRoute.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/home/HomeRoute.kt
@@ -1,14 +1,18 @@
 package com.knocklock.presentation.home
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.knocklock.presentation.home.menu.HomeMenu
 
 @Composable
 fun HomeRoute(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    homeScreenUiState: HomeScreenUiState,
+    onClickHomeMenu: (HomeMenu) -> Unit
 ) {
-    Box(modifier = modifier) {
-
-    }
+    HomeScreen(
+        modifier = modifier,
+        homeScreenUiState = homeScreenUiState,
+        onClickHomeMenu = onClickHomeMenu
+    )
 }

--- a/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
@@ -1,0 +1,23 @@
+package com.knocklock.presentation.home
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.knocklock.presentation.home.menu.HomeMenu
+import com.knocklock.presentation.home.menu.HomeMenuBar
+
+@Composable
+fun HomeScreen(
+    modifier: Modifier = Modifier,
+    homeScreenUiState: HomeScreenUiState,
+    onClickHomeMenu: (HomeMenu) -> Unit
+) {
+    Box(modifier = modifier) {
+        HomeMenuBar(
+            modifier = Modifier.align(Alignment.TopEnd),
+            menuList = homeScreenUiState.menuList,
+            onClickHomeMenu = onClickHomeMenu
+        )
+    }
+}

--- a/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
@@ -1,6 +1,9 @@
 package com.knocklock.presentation.home
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -13,9 +16,12 @@ fun HomeScreen(
     homeScreenUiState: HomeScreenUiState,
     onClickHomeMenu: (HomeMenu) -> Unit
 ) {
-    Box(modifier = modifier) {
+    Box(modifier = modifier.navigationBarsPadding()) {
         HomeMenuBar(
-            modifier = Modifier.align(Alignment.TopEnd),
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .align(Alignment.TopEnd),
             menuList = homeScreenUiState.menuList,
             onClickHomeMenu = onClickHomeMenu
         )

--- a/presentation/src/main/java/com/knocklock/presentation/home/HomeScreenUiState.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/home/HomeScreenUiState.kt
@@ -1,0 +1,8 @@
+package com.knocklock.presentation.home
+
+import com.knocklock.presentation.home.menu.HomeMenu
+import kotlinx.collections.immutable.ImmutableList
+
+data class HomeScreenUiState(
+    val menuList: ImmutableList<HomeMenu>
+)

--- a/presentation/src/main/java/com/knocklock/presentation/home/menu/HomeMenu.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/home/menu/HomeMenu.kt
@@ -1,0 +1,10 @@
+package com.knocklock.presentation.home.menu
+
+import androidx.annotation.StringRes
+import com.knocklock.presentation.R
+
+enum class HomeMenu(@StringRes val textRes: Int) {
+    CLEAR(R.string.home_menu_clear),
+    SAVE(R.string.home_menu_save),
+    SETTING(R.string.setting)
+}

--- a/presentation/src/main/java/com/knocklock/presentation/home/menu/HomeMenuBar.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/home/menu/HomeMenuBar.kt
@@ -1,0 +1,55 @@
+package com.knocklock.presentation.home.menu
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+
+@Composable
+fun HomeMenuBar(
+    modifier: Modifier = Modifier,
+    menuList: ImmutableList<HomeMenu>,
+    onClickHomeMenu: (HomeMenu) -> Unit
+) {
+    Row(
+        modifier = modifier.background(color = Color.Black.copy(alpha = 0.5f)),
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        menuList.forEach { homeMenu ->
+            HomeMenuItem(
+                modifier = Modifier.clickable { onClickHomeMenu(homeMenu) },
+                homeMenu = homeMenu,
+            )
+        }
+    }
+}
+
+@Composable
+fun HomeMenuItem(
+    modifier: Modifier = Modifier,
+    homeMenu: HomeMenu
+) {
+    Text(
+        modifier = modifier,
+        text = stringResource(id = homeMenu.textRes),
+        color = Color.White
+    )
+}
+
+@Preview
+@Composable
+fun HomeMenuBarPrev() {
+    HomeMenuBar(
+        menuList = HomeMenu.values().toList().toImmutableList()
+    ) {
+    }
+}

--- a/presentation/src/main/java/com/knocklock/presentation/home/menu/HomeMenuBar.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/home/menu/HomeMenuBar.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -21,12 +22,16 @@ fun HomeMenuBar(
     onClickHomeMenu: (HomeMenu) -> Unit
 ) {
     Row(
-        modifier = modifier.background(color = Color.Black.copy(alpha = 0.5f)),
-        horizontalArrangement = Arrangement.spacedBy(16.dp)
+        modifier = Modifier
+            .background(color = Color.Black.copy(alpha = 0.5f))
+            .then(modifier),
+        horizontalArrangement = Arrangement.End
     ) {
         menuList.forEach { homeMenu ->
             HomeMenuItem(
-                modifier = Modifier.clickable { onClickHomeMenu(homeMenu) },
+                modifier = Modifier.clickable { onClickHomeMenu(homeMenu) }
+                    .padding(vertical = 16.dp, horizontal = 12.dp)
+                ,
                 homeMenu = homeMenu,
             )
         }

--- a/presentation/src/main/java/com/knocklock/presentation/navigation/KnockLockNavHost.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/navigation/KnockLockNavHost.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import com.knocklock.presentation.R
+import com.knocklock.presentation.home.HomeRoute
 import com.knocklock.presentation.setting.password.PasswordInputRoute
 import com.knocklock.presentation.setting.SettingRoute
 import com.knocklock.presentation.setting.credit.CreditRoute
@@ -21,11 +22,28 @@ fun KnockLockNavHost(
     NavHost(
         modifier = modifier,
         navController = navController,
-        startDestination = NavigationRoute.SettingGraph.route
+        startDestination = NavigationRoute.HomeGraph.route
     ) {
+        homeGraph(
+            modifier, navController
+        )
+
         settingGraph(
             modifier, navController
         )
+    }
+}
+fun NavGraphBuilder.homeGraph(
+    modifier: Modifier = Modifier,
+    navController: NavController
+) {
+    navigation(
+        startDestination = NavigationRoute.HomeGraph.Home.route,
+        route = NavigationRoute.HomeGraph.route
+    ) {
+        composable(route = NavigationRoute.HomeGraph.Home.route) {
+            HomeRoute(modifier = modifier)
+        }
     }
 }
 

--- a/presentation/src/main/java/com/knocklock/presentation/navigation/KnockLockNavHost.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/navigation/KnockLockNavHost.kt
@@ -10,9 +10,15 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import com.knocklock.presentation.R
 import com.knocklock.presentation.home.HomeRoute
+import com.knocklock.presentation.home.HomeScreenUiState
+import com.knocklock.presentation.home.menu.HomeMenu
 import com.knocklock.presentation.setting.password.PasswordInputRoute
 import com.knocklock.presentation.setting.SettingRoute
 import com.knocklock.presentation.setting.credit.CreditRoute
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.immutableListOf
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun KnockLockNavHost(
@@ -42,7 +48,19 @@ fun NavGraphBuilder.homeGraph(
         route = NavigationRoute.HomeGraph.route
     ) {
         composable(route = NavigationRoute.HomeGraph.Home.route) {
-            HomeRoute(modifier = modifier)
+            HomeRoute(
+                modifier = modifier,
+                onClickHomeMenu = { homeMenu ->
+                    when (homeMenu) {
+                        HomeMenu.SETTING -> {
+                            navController.navigate(NavigationRoute.SettingGraph.route)
+                        }
+                        else -> {
+                        }
+                    }
+                },
+                homeScreenUiState = HomeScreenUiState(listOf(HomeMenu.SETTING).toImmutableList())
+            )
         }
     }
 }

--- a/presentation/src/main/java/com/knocklock/presentation/navigation/NavigationRoute.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/navigation/NavigationRoute.kt
@@ -3,6 +3,14 @@ package com.knocklock.presentation.navigation
 sealed class NavigationRoute {
     abstract val route: String
 
+    object HomeGraph : NavigationRoute() {
+        override val route: String = "home_graph"
+
+        object Home : Direction {
+            override val route: String = "home"
+        }
+    }
+
     object SettingGraph : NavigationRoute() {
         override val route: String = "setting_graph"
 

--- a/presentation/src/main/java/com/knocklock/presentation/setting/SettingScreen.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/setting/SettingScreen.kt
@@ -47,12 +47,13 @@ fun SettingScreen(
     userSettings: UserSettings
 ) {
     Scaffold(
-        topBar = { SettingHeader(modifier) },
+        modifier = modifier,
+        topBar = { SettingHeader(Modifier.fillMaxWidth()) },
     ) {
         Column(modifier.padding(it)) {
-            Spacer(modifier.padding(20.dp))
+            Spacer(Modifier.fillMaxWidth().padding(20.dp))
             SettingBody(
-                modifier,
+                Modifier.fillMaxWidth(),
                 onMenuSelected,
                 onPasswordActivatedChanged,
                 onLockActivatedChanged,

--- a/presentation/src/main/res/values-v27/themes.xml
+++ b/presentation/src/main/res/values-v27/themes.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
-
-    <style name="LockScreenActivity">
-        <item name="android:windowLayoutInDisplayCutoutMode" tools:ignore="NewApi">
-            shortEdges
-        </item>
-    </style>
-</resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -28,4 +28,6 @@
     <string name="desc_password_input">잠금 설정을 위한 비밀번호를 입력하세요.</string>
     <string name="desc_password_input_confirm">비밀번호 확인을 위해 다시 입력해주세요.</string>
     <string name="desc_forget_password">비밀번호를 잊어버리셨다면 뒤로 돌아가주세요.</string>
+    <string name="home_menu_clear">초기화</string>
+    <string name="home_menu_save">저장</string>
 </resources>

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-
-    <style name="Theme.MainActivity" parent="android:Theme.Material.Light.NoActionBar" />
-</resources>


### PR DESCRIPTION
## 🔥 관련 이슈

close #76 

## 🔥 PR Point

- WindowCompat으로 상태바, NavgationBar 영역까지 확장
-> 추후 잠금화면 미리보기 화면 등에서 상태바 영역까지 확장해서 그리면 이쁠 것 같아요

- Setting Modifier 영역 수정

## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|홈 화면|<img src="https://user-images.githubusercontent.com/33657541/215333297-7c0574e7-1930-4707-ad55-70ac7b86192a.png" width="40%">|
