### PR TITLE
Feature/connect update pass word

### DIFF
--- a/presentation/src/main/java/com/knocklock/presentation/setting/password/PasswordInputRoute.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/setting/password/PasswordInputRoute.kt
@@ -3,6 +3,8 @@ package com.knocklock.presentation.setting.password
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -30,6 +32,6 @@ fun PasswordInputRoute(
         modifier = modifier.fillMaxSize(),
         state = viewModel.passwordInputState,
         onClickTextButton = viewModel::onClickTextButton,
-        onClickAction = viewModel::onClickKeyboardAction,
+        onClickAction = viewModel::onClickKeyboardAction
     )
 }

--- a/presentation/src/main/java/com/knocklock/presentation/setting/password/PasswordInputViewModel.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/setting/password/PasswordInputViewModel.kt
@@ -52,7 +52,7 @@ class PasswordInputViewModel @Inject constructor(
             }
         }
 
-        if (state.inputPassword.length + 1 >= MAX_PASSWORD_LENGTH) {
+        if (passwordInputState.inputPassword.length >= MAX_PASSWORD_LENGTH) {
             when (passwordInputState) {
                 is PasswordInputState.PasswordNoneState -> {
                     checkPasswordNoneState(passwordInputState as PasswordInputState.PasswordNoneState)

--- a/presentation/src/main/java/com/knocklock/presentation/setting/password/PasswordInputViewModel.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/setting/password/PasswordInputViewModel.kt
@@ -90,6 +90,7 @@ class PasswordInputViewModel @Inject constructor(
 
         passwordInputState = if (state.inputPassword == state.savedPassword) {
             viewModelScope.launch {
+                updatePasswordUseCase(state.savedPassword)
                 _onSuccessUpdatePassword.emit(Unit)
             }
             state.copy(isLoading = false, mismatchPassword = false)

--- a/presentation/src/main/java/com/knocklock/presentation/setting/password/PasswordInputViewModel.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/setting/password/PasswordInputViewModel.kt
@@ -53,12 +53,12 @@ class PasswordInputViewModel @Inject constructor(
         }
 
         if (state.inputPassword.length + 1 >= MAX_PASSWORD_LENGTH) {
-            when (state) {
+            when (passwordInputState) {
                 is PasswordInputState.PasswordNoneState -> {
-                    checkPasswordNoneState(state)
+                    checkPasswordNoneState(passwordInputState as PasswordInputState.PasswordNoneState)
                 }
                 is PasswordInputState.PasswordConfirmState -> {
-                    checkPasswordConfirmState(state)
+                    checkPasswordConfirmState(passwordInputState as PasswordInputState.PasswordConfirmState)
                 }
             }
         }


### PR DESCRIPTION
## 🔥 관련 이슈

close #85 

## 🔥 PR Point
```kotlin
-            when (state) {
            when (passwordInputState) {
                is PasswordInputState.PasswordNoneState -> {
-                    checkPasswordNoneState(state)
                    checkPasswordNoneState(passwordInputState as PasswordInputState.PasswordNoneState)
                }
                is PasswordInputState.PasswordConfirmState -> {
-                    checkPasswordConfirmState(state)
                    checkPasswordConfirmState(passwordInputState as PasswordInputState.PasswordConfirmState)
```
기존에는 
```kotlin
passwordInputState = when (state) {
            is PasswordInputState.PasswordNoneState -> {
                state.copy(inputPassword = state.inputPassword + newPasswordNumber)
            }
            is PasswordInputState.PasswordConfirmState -> {
                state.copy(inputPassword = state.inputPassword + newPasswordNumber)
            }
        }
```
state를 copy한 값에 더해도 passwordInputState가 업데이트 되기 떄문에 when 안에 state를 넣으면 가장 최근 값이 갱신이 되지않는 값이 넘어오게 되어있었습니다.


대신 스마트 캐스팅이 되지 않네영