### PR TITLE
[feature]: home 화면 palette 적용

### DIFF
--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -97,4 +97,5 @@ dependencies {
     // lottie
     implementation "com.airbnb.android:lottie-compose:5.2.0"
 
+    implementation('androidx.palette:palette:1.0.0')
 }

--- a/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
@@ -5,20 +5,18 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.zIndex
 import androidx.core.graphics.drawable.toBitmap
 import androidx.palette.graphics.Palette
 import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
-import coil.compose.rememberImagePainter
 import coil.request.ImageRequest
 import com.knocklock.domain.model.LockScreen
 import com.knocklock.domain.model.LockScreenBackground
@@ -26,6 +24,9 @@ import com.knocklock.presentation.R
 import com.knocklock.presentation.home.menu.HomeMenu
 import com.knocklock.presentation.home.menu.HomeMenuBar
 import com.knocklock.presentation.ui.theme.KnockLockTheme
+import com.knocklock.presentation.util.defaultGradientColors
+import com.knocklock.presentation.util.getGradientColors
+import com.knocklock.presentation.util.getPalette
 import kotlinx.collections.immutable.toImmutableList
 
 @Composable
@@ -84,15 +85,24 @@ fun HomeContent(
     }
 
     val palette = (imagePainter.state as? AsyncImagePainter.State.Success)?.let {
-        Palette.from((it.result.drawable.toBitmap())).generate()
+        getPalette(it.result.drawable.toBitmap())
     }
 
-    val backgroundColor = palette?.mutedSwatch?.let { Color(it.rgb) } ?: Color.Transparent
+    val backgroundGradientBrush = Brush.linearGradient(
+        colors = palette?.let { getGradientColors(palette) } ?: defaultGradientColors,
+        start = Offset.Zero,
+        end = Offset.Infinite,
+    )
 
     Box(
         modifier = modifier
-            .background(color = backgroundColor)
     ) {
+        Box(
+            modifier = modifier.background(
+                brush = backgroundGradientBrush,
+                alpha = 0.6f
+            )
+        )
         Image(
             modifier = Modifier
                 .fillMaxSize(0.6f)
@@ -100,7 +110,6 @@ fun HomeContent(
             painter = imagePainter,
             contentDescription = null,
             contentScale = ContentScale.FillBounds,
-            alpha = 0.4f
         )
     }
 }

--- a/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
@@ -105,7 +105,7 @@ fun HomeContent(
         )
         Image(
             modifier = Modifier
-                .fillMaxSize(0.6f)
+                .fillMaxSize(0.8f)
                 .align(Alignment.Center),
             painter = imagePainter,
             contentDescription = null,

--- a/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
@@ -1,23 +1,31 @@
 package com.knocklock.presentation.home
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.graphics.drawable.toBitmap
+import androidx.palette.graphics.Palette
+import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
+import coil.compose.rememberImagePainter
 import coil.request.ImageRequest
 import com.knocklock.domain.model.LockScreen
 import com.knocklock.domain.model.LockScreenBackground
 import com.knocklock.presentation.R
 import com.knocklock.presentation.home.menu.HomeMenu
 import com.knocklock.presentation.home.menu.HomeMenuBar
+import com.knocklock.presentation.ui.theme.KnockLockTheme
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun HomeScreen(
@@ -39,36 +47,10 @@ fun HomeScreen(
                     onClickHomeMenu = onClickHomeMenu
                 )
             }
-            when (homeScreenUiState.lockScreen.background) {
-                is LockScreenBackground.DefaultWallPaper -> {
-                    Image(
-                        modifier = modifier,
-                        painter = rememberAsyncImagePainter(
-                            ImageRequest
-                                .Builder(LocalContext.current)
-                                .data(R.drawable.default_wallpaper)
-                                .build()
-                        ),
-                        contentDescription = null,
-                        contentScale = ContentScale.FillBounds,
-                        alpha = 0.4f
-                    )
-                }
-                is LockScreenBackground.LocalImage -> {
-                    Image(
-                        modifier = modifier,
-                        painter = rememberAsyncImagePainter(
-                            ImageRequest
-                                .Builder(LocalContext.current)
-                                .data((homeScreenUiState.lockScreen.background as LockScreenBackground.LocalImage).imageUri)
-                                .build()
-                        ),
-                        contentScale = ContentScale.FillBounds,
-                        contentDescription = null,
-                        alpha = 0.4f
-                    )
-                }
-            }
+            HomeContent(
+                modifier = Modifier.fillMaxSize(),
+                homeScreenUiState = homeScreenUiState
+            )
         }
     }
 }
@@ -76,9 +58,63 @@ fun HomeScreen(
 @Composable
 fun HomeContent(
     modifier: Modifier = Modifier,
-    lockScreen: LockScreen
+    homeScreenUiState: HomeScreenUiState.Success,
 ) {
-    Box(modifier = modifier) {
-        // implement LockScreen
+    val imagePainter = when (homeScreenUiState.lockScreen.background) {
+        is LockScreenBackground.DefaultWallPaper -> {
+            rememberAsyncImagePainter(
+                ImageRequest
+                    .Builder(LocalContext.current)
+                    .data(R.drawable.default_wallpaper)
+                    .allowHardware(false)
+                    .build()
+            )
+        }
+        is LockScreenBackground.LocalImage -> {
+            rememberAsyncImagePainter(
+                ImageRequest
+                    .Builder(LocalContext.current)
+                    .data((homeScreenUiState.lockScreen.background as LockScreenBackground.LocalImage).imageUri)
+                    .allowHardware(false)
+                    .build()
+            )
+        }
+    }
+
+    val palette = (imagePainter.state as? AsyncImagePainter.State.Success)?.let {
+        Palette.from((it.result.drawable.toBitmap())).generate()
+    }
+
+    val backgroundColor = palette?.mutedSwatch?.let { Color(it.rgb) } ?: Color.Transparent
+
+    Box(
+        modifier = modifier
+            .background(color = backgroundColor)
+    ) {
+        Image(
+            modifier = Modifier
+                .fillMaxSize(0.6f)
+                .align(Alignment.Center),
+            painter = imagePainter,
+            contentDescription = null,
+            contentScale = ContentScale.FillBounds,
+            alpha = 0.4f
+        )
+    }
+}
+
+@Preview
+@Composable
+fun HomeContentPrev() {
+    KnockLockTheme {
+        Surface {
+            HomeContent(
+                modifier = Modifier.fillMaxSize(),
+                homeScreenUiState = HomeScreenUiState.Success(
+                    lockScreen = LockScreen(LockScreenBackground.DefaultWallPaper),
+                    menuList = emptyList<HomeMenu>().toImmutableList()
+                )
+            )
+        }
     }
 }

--- a/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.zIndex
 import androidx.core.graphics.drawable.toBitmap
 import androidx.palette.graphics.Palette
 import coil.compose.AsyncImagePainter
@@ -42,15 +43,16 @@ fun HomeScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .statusBarsPadding()
-                        .align(Alignment.TopEnd),
+                        .align(Alignment.TopEnd)
+                        .zIndex(1f),
                     menuList = homeScreenUiState.menuList,
                     onClickHomeMenu = onClickHomeMenu
                 )
+                HomeContent(
+                    modifier = Modifier.fillMaxSize(),
+                    homeScreenUiState = homeScreenUiState
+                )
             }
-            HomeContent(
-                modifier = Modifier.fillMaxSize(),
-                homeScreenUiState = homeScreenUiState
-            )
         }
     }
 }

--- a/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
@@ -105,7 +105,7 @@ fun HomeContent(
         )
         Image(
             modifier = Modifier
-                .fillMaxSize(0.8f)
+                .fillMaxSize(0.75f)
                 .align(Alignment.Center),
             painter = imagePainter,
             contentDescription = null,

--- a/presentation/src/main/java/com/knocklock/presentation/util/PaletteUtil.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/util/PaletteUtil.kt
@@ -1,0 +1,32 @@
+package com.knocklock.presentation.util
+
+import android.graphics.Bitmap
+import androidx.compose.ui.graphics.Color
+import androidx.palette.graphics.Palette
+
+val defaultGradientColors = listOf(Color.Transparent, Color.Transparent)
+
+fun getPalette(bitmap: Bitmap): Palette {
+    return Palette.from(bitmap)
+        .maximumColorCount(10)
+        .generate()
+}
+
+fun getGradientColors(palette: Palette): List<Color> {
+    val colors = mutableListOf<Color>().apply {
+        palette.lightVibrantSwatch?.rgb?.let(::addColorWithRGB)
+        palette.vibrantSwatch?.rgb?.let(::addColorWithRGB)
+        palette.mutedSwatch?.rgb?.let(::addColorWithRGB)
+        palette.lightMutedSwatch?.rgb?.let(::addColorWithRGB)
+    }
+
+    return if (colors.size >= 2) {
+        colors
+    } else {
+        defaultGradientColors
+    }
+}
+
+private fun MutableList<Color>.addColorWithRGB(rgb: Int) {
+    add(Color(rgb))
+}


### PR DESCRIPTION
## 🔥 관련 이슈

close #99 

## 🔥 PR Point

- 기존 와이어프레임에서는 잠금화면 Blur를 이용한 배경화면 이었는데 흠..
Palette를 사용해서 구현하는 것은 어때요?? [가벼운 제안입니다!!]

Palette로 백그라운드를 그린다면 좀 더 단색 느낌을 줘서 잠금화면 컨텐츠에 집중하게 할수 있지않을까요?

+ 더 컬러를 뽑아서 그라데이션으로 표현해도 좋을 것 같아요

## 📷 Screenshot
|기능|스크린샷| 스크린샷 2|
|:---|---|---|
|Platte를 적용한 홈 화면|![image](https://user-images.githubusercontent.com/33657541/222969653-1ae0985a-8add-4e59-93cb-574f8620ef24.png)|![image](https://user-images.githubusercontent.com/33657541/222969715-42598a46-816b-4433-ab94-161577234ec4.png)|

