### PR TITLE
ChildNotification을 LazyColumn 내부에서 처리

### DIFF
--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation 'androidx.compose.material3:material3:1.0.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1"
+    implementation "androidx.lifecycle:lifecycle-runtime-compose:2.6.1"
 
     testImplementation 'junit:junit:4.13.2'
 

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreen.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreen.kt
@@ -267,11 +267,11 @@ fun TextClockComposable(
     )
 }
 
-suspend fun updateExpandable(expandableState: SnapshotStateMap<String, Boolean>, key: String) {
+fun updateExpandable(expandableState: SnapshotStateMap<String, Boolean>, key: String) {
     if (!expandableState.containsKey(key)) {
         expandableState[key] = false
     }
 }
-suspend fun updateClickable(clickableState: SnapshotStateMap<String, Boolean>, key: String, flag: Boolean) {
+fun updateClickable(clickableState: SnapshotStateMap<String, Boolean>, key: String, flag: Boolean) {
     clickableState[key] = flag
 }

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreen.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreen.kt
@@ -192,11 +192,6 @@ fun LockScreenNotificationListColumn(
             launch(Dispatchers.Default) {
                 updateExpandable(expandableState, groupWithNotification.group.key)
             }
-        }
-    }
-
-    LaunchedEffect(groupNotificationList) {
-        groupNotificationList.forEach { groupWithNotification ->
             launch(Dispatchers.Default) {
                 updateClickable(clickableState, groupWithNotification.group.key, groupWithNotification.notifications.size >= 2)
             }

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenActivity.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenActivity.kt
@@ -14,15 +14,13 @@ import android.view.Gravity
 import android.view.View
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
 import androidx.activity.setViewTreeOnBackPressedDispatcherOwner
-import androidx.activity.viewModels
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.compositionContext
 import androidx.compose.ui.platform.createLifecycleAwareWindowRecomposer
-import androidx.lifecycle.ViewTreeLifecycleOwner
-import androidx.lifecycle.ViewTreeViewModelStoreOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.knocklock.presentation.lockscreen.service.LockScreenNotificationListener
 import dagger.hilt.android.AndroidEntryPoint
@@ -32,10 +30,6 @@ class LockScreenActivity : ComponentActivity() {
 
     private var composeView: ComposeView? = null
 
-    private val manager by lazy {
-        this.applicationContext.packageManager
-    }
-
     private val window by lazy {
         this.applicationContext.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     }
@@ -43,7 +37,6 @@ class LockScreenActivity : ComponentActivity() {
     private val point by lazy { Point() }
     private var notificationListener: LockScreenNotificationListener? = null
     private var mBound: Boolean = false
-    private val vm: LockScreenViewModel by viewModels()
 
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(p0: ComponentName?, service: IBinder) {
@@ -71,8 +64,6 @@ class LockScreenActivity : ComponentActivity() {
                     onRemoveNotifications = { keys ->
                         if (mBound) notificationListener?.cancelNotifications(keys)
                     },
-                    vm = vm,
-                    packageManager = manager,
                 )
             }
             initViewTreeOwner(this)
@@ -103,8 +94,8 @@ class LockScreenActivity : ComponentActivity() {
     @OptIn(ExperimentalComposeUiApi::class)
     private fun initViewTreeOwner(composeView: ComposeView) {
         composeView.apply {
-            ViewTreeLifecycleOwner.set(this, this@LockScreenActivity)
-            ViewTreeViewModelStoreOwner.set(this, this@LockScreenActivity)
+            setViewTreeLifecycleOwner(this@LockScreenActivity)
+            setViewTreeViewModelStoreOwner(this@LockScreenActivity)
             setViewTreeSavedStateRegistryOwner(this@LockScreenActivity)
             setViewTreeOnBackPressedDispatcherOwner(this@LockScreenActivity)
             compositionContext = createLifecycleAwareWindowRecomposer(lifecycle = lifecycle)

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenNotiItem.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenNotiItem.kt
@@ -4,8 +4,6 @@ import android.app.PendingIntent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
@@ -33,84 +31,11 @@ import com.knocklock.presentation.lockscreen.util.FractionalThreshold
 import com.knocklock.presentation.lockscreen.util.SwipeToDismiss
 import com.knocklock.presentation.lockscreen.util.rememberDismissState
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
 
 /**
  * @Created by 김현국 2022/12/02
  * @Time 3:06 PM
  */
-
-@Composable
-fun GroupLockNotiItem(
-    modifier: Modifier = Modifier,
-    notificationList: ImmutableList<Notification>,
-    onRemoveNotification: (List<String>) -> Unit,
-    onNotificationClicked: (PendingIntent) -> Unit
-) {
-    if (notificationList.isEmpty()) {
-        return
-    }
-    val notification by rememberUpdatedState(notificationList[0])
-    var clickableState by remember { mutableStateOf(false) }
-    var expandableState by remember { mutableStateOf(false) }
-    LaunchedEffect(notificationList.size) {
-        clickableState = notificationList.size >= 2
-        if (notificationList.isEmpty()) {
-            expandableState = false
-        }
-    }
-    Column(
-        modifier = modifier.clickable(
-            enabled = clickableState,
-            indication = null,
-            interactionSource = remember { MutableInteractionSource() }
-        ) {
-            expandableState = !expandableState
-        }
-    ) {
-        val lockNotiModifier = modifier
-            .background(
-                color = Color(0xFFFAFAFA).copy(alpha = 0.95f),
-                shape = RoundedCornerShape(10.dp)
-            )
-            .clip(RoundedCornerShape(10.dp))
-        key(notification.postedTime) {
-            SwipeToDismissLockNotiItem(
-                modifier = lockNotiModifier,
-                onRemoveNotification = onRemoveNotification,
-                notification = notification,
-                notificationSize = notificationList.size,
-                clickableState = clickableState,
-                expandableState = expandableState,
-                groupNotification = notificationList.toImmutableList(),
-                onNotificationClicked = onNotificationClicked
-            )
-        }
-
-        AnimatedVisibility(visible = expandableState && notificationList.size != 1) {
-            Column(
-                modifier = modifier.padding(top = 4.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                for (index in 1 until notificationList.size) {
-                    key(notificationList[index].postedTime) {
-                        SwipeToDismissLockNotiItem(
-                            modifier = lockNotiModifier,
-                            onRemoveNotification = { list ->
-                                onRemoveNotification(list)
-                            },
-                            notification = notificationList[index],
-                            notificationSize = notificationList.size,
-                            clickableState = false,
-                            expandableState = expandableState,
-                            onNotificationClicked = onNotificationClicked
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -122,7 +47,7 @@ fun SwipeToDismissLockNotiItem(
     notificationSize: Int,
     clickableState: Boolean,
     expandableState: Boolean,
-    groupNotification: ImmutableList<Notification>? = null
+    groupNotification: ImmutableList<Notification>? = null,
 ) {
     val updateGroupNotification by rememberUpdatedState(newValue = groupNotification)
     val updateNotification by rememberUpdatedState(newValue = notification)
@@ -144,7 +69,7 @@ fun SwipeToDismissLockNotiItem(
                             onRemoveNotification(
                                 childNotificationList.map { notification ->
                                     notification.id
-                                }
+                                },
                             )
                         }
                     }
@@ -163,7 +88,7 @@ fun SwipeToDismissLockNotiItem(
                 Box {
                     LockNotiItem(
                         modifier = modifier,
-                        notification = updateNotification
+                        notification = updateNotification,
                     )
                     if (clickableState) {
                         Icon(
@@ -171,7 +96,7 @@ fun SwipeToDismissLockNotiItem(
                                 .align(Alignment.CenterEnd)
                                 .padding(end = 5.dp),
                             imageVector = if (expandableState) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
-                            contentDescription = null
+                            contentDescription = null,
                         )
                     }
                 }
@@ -182,33 +107,33 @@ fun SwipeToDismissLockNotiItem(
                                 modifier = Modifier
                                     .padding(horizontal = 15.dp)
                                     .fillMaxWidth()
-                                    .height(7.dp)
+                                    .height(7.dp),
                             )
                         } else if (notificationSize >= 3) {
                             MoreNotification(
                                 modifier = Modifier
                                     .padding(horizontal = 15.dp)
                                     .fillMaxWidth()
-                                    .height(7.dp)
+                                    .height(7.dp),
                             )
                             MoreNotification(
                                 modifier = Modifier
                                     .padding(horizontal = 35.dp)
                                     .fillMaxWidth()
-                                    .height(5.dp)
+                                    .height(5.dp),
                             )
                         }
                     }
                 }
             }
         },
-        background = {}
+        background = {},
     )
 }
 
 @Composable
 fun MoreNotification(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val moreNotificationShape = RoundedCornerShape(bottomStart = 5.dp, bottomEnd = 5.dp)
     Row(
@@ -217,23 +142,23 @@ fun MoreNotification(
                 brush = Brush.verticalGradient(
                     listOf(
                         Color(0xFFFAFAFA).copy(alpha = 0.9f),
-                        Color.LightGray
-                    )
+                        Color.LightGray,
+                    ),
                 ),
-                shape = moreNotificationShape
+                shape = moreNotificationShape,
             )
-            .clip(shape = moreNotificationShape)
+            .clip(shape = moreNotificationShape),
     ) {}
 }
 
 @Composable
 fun LockNotiItem(
     modifier: Modifier = Modifier,
-    notification: Notification
+    notification: Notification,
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(4.dp)
+        verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         LockNotiTop(
             modifier = Modifier
@@ -241,7 +166,7 @@ fun LockNotiItem(
                 .padding(top = 4.dp),
             packageName = notification.packageName,
             appTitle = notification.appTitle,
-            time = notification.notiTime
+            time = notification.notiTime,
         )
         LockNotiContent(
             modifier = Modifier
@@ -249,7 +174,7 @@ fun LockNotiItem(
                 .padding(bottom = 4.dp)
                 .wrapContentHeight(),
             title = notification.title,
-            content = notification.content
+            content = notification.content,
         )
     }
 }
@@ -259,35 +184,35 @@ fun LockNotiTop(
     modifier: Modifier = Modifier,
     packageName: String?,
     appTitle: String,
-    time: String
+    time: String,
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
             .wrapContentHeight(),
-        horizontalArrangement = Arrangement.SpaceBetween
+        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         Row(
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             if (packageName != null) {
                 Image(
                     modifier = Modifier.size(10.dp),
                     painter = rememberDrawablePainter(
-                        drawable = LocalContext.current.packageManager.getApplicationIcon(packageName)
+                        drawable = LocalContext.current.packageManager.getApplicationIcon(packageName),
                     ),
-                    contentDescription = null
+                    contentDescription = null,
                 )
             }
             Spacer(modifier = Modifier.width(4.dp))
             Text(
                 text = appTitle,
-                fontSize = 10.sp
+                fontSize = 10.sp,
             )
         }
         Text(
             text = time,
-            fontSize = 10.sp
+            fontSize = 10.sp,
         )
     }
 }
@@ -296,21 +221,21 @@ fun LockNotiTop(
 fun LockNotiContent(
     modifier: Modifier = Modifier,
     title: String,
-    content: String
+    content: String,
 ) {
     Column(
-        modifier = modifier
+        modifier = modifier,
     ) {
         Text(
             title,
             overflow = TextOverflow.Ellipsis,
             maxLines = 1,
-            fontWeight = FontWeight.W700
+            fontWeight = FontWeight.W700,
         )
         Text(
             content,
             overflow = TextOverflow.Ellipsis,
-            maxLines = 1
+            maxLines = 1,
         )
     }
 }

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenUiState.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenUiState.kt
@@ -9,6 +9,11 @@ import com.knocklock.presentation.lockscreen.model.GroupWithNotification
 sealed class NotificationUiState {
     object Empty : NotificationUiState()
     data class Success(
-        val groupWithNotification: List<GroupWithNotification>
+        val groupWithNotification: List<GroupWithNotification>,
     ) : NotificationUiState()
 }
+
+data class NotificationUiFlagState(
+    val expandable: Boolean = false,
+    val clickable: Boolean = false,
+)

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/service/LockScreenNotificationListener.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/service/LockScreenNotificationListener.kt
@@ -71,7 +71,7 @@ class LockScreenNotificationListener :
                 override fun openLockScreenByIntent() {
                     addLockScreen()
                 }
-            }
+            },
         )
     }
 
@@ -82,7 +82,7 @@ class LockScreenNotificationListener :
                 override fun onSystemBarClicked() {
                     // Todo 현재 PassWordScreen이 열려있는지
                 }
-            }
+            },
         )
     }
 
@@ -95,8 +95,8 @@ class LockScreenNotificationListener :
                     val notification = sbn.toModel(packageManager)
                     notificationRepository.insertGroup(
                         Group(
-                            key = notification.groupKey
-                        ).toModel()
+                            key = notification.groupKey,
+                        ).toModel(),
                     )
                     notificationRepository.insertNotifications(notification)
                 }
@@ -128,15 +128,15 @@ class LockScreenNotificationListener :
                     notification.getDatabaseKey(packageManager)?.let { key ->
                         notificationRepository.insertGroup(
                             Group(
-                                key = key
-                            ).toModel()
+                                key = key,
+                            ).toModel(),
                         )
                     }
                 }
             }
 
             notificationRepository.insertNotifications(
-                *toModel(copyActiveNotification, packageManager)
+                *toModel(copyActiveNotification, packageManager),
             )
         }
     }
@@ -165,7 +165,7 @@ class LockScreenNotificationListener :
             builder.append("package:$packageName")
             val intent = Intent(
                 "android.settings.action.MANAGE_OVERLAY_PERMISSION",
-                Uri.parse(builder.toString())
+                Uri.parse(builder.toString()),
             ).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
@@ -192,7 +192,7 @@ class LockScreenNotificationListener :
         val channel = NotificationChannel(
             ANDROID_CHANNEL_ID,
             ANDROID_CHANNEL_NAME,
-            NotificationManager.IMPORTANCE_HIGH
+            NotificationManager.IMPORTANCE_HIGH,
         ).apply {
             lockscreenVisibility = Notification.VISIBILITY_PUBLIC
         }
@@ -205,7 +205,7 @@ class LockScreenNotificationListener :
             this,
             0,
             contentIntent,
-            PendingIntent.FLAG_IMMUTABLE
+            PendingIntent.FLAG_IMMUTABLE,
         )
 
         return NotificationCompat.Builder(this, ANDROID_CHANNEL_ID)


### PR DESCRIPTION
## 🔥 관련 이슈

close #114

## 🔥 PR Point

- ChildNotification을 LazyColumn으로 hoisting.
- GroupNotiItem에서 관리하던 expandable, clickable state를 mutableStateMap으로 처리했습니다. 
- KtLint 적용시 후행 컴마가 생기던데, https://medium.com/@sanketmeghani/kotlin-1-4-trailing-commas-53c690eced32 
사용하면 어떤 것을 수정했는지 명확하다고 하더군요! 추가시 한줄만 수정이 반영되성
