### PR TITLE
Feature/refactor code

### DIFF
--- a/data/src/main/java/com/knocklock/data/repository/NotificationRepositoryImpl.kt
+++ b/data/src/main/java/com/knocklock/data/repository/NotificationRepositoryImpl.kt
@@ -23,11 +23,9 @@ class NotificationRepositoryImpl @Inject constructor(
         groupDao.insertGroup(group = group.toEntity())
     }
 
-    override suspend fun insertNotifications(vararg notifications: Notification) {
+    override suspend fun insertNotifications(notification: Notification) {
         notificationDao.insertNotifications(
-            *notifications.map { notification ->
                 notification.toEntity()
-            }.toTypedArray()
         )
     }
 
@@ -50,8 +48,8 @@ class NotificationRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun removeNotificationsWithId(vararg ids: String) {
-        notificationDao.deleteNotificationsWithIds(*ids)
+    override suspend fun removeNotificationsWithId(id: String) {
+        notificationDao.deleteNotificationsWithId(id)
     }
 
     override suspend fun removeGroupWithNotifications(key: String) {

--- a/data/src/main/java/com/knocklock/data/source/local/notification/dao/NotificationDao.kt
+++ b/data/src/main/java/com/knocklock/data/source/local/notification/dao/NotificationDao.kt
@@ -14,12 +14,12 @@ import com.knocklock.data.source.local.notification.entity.Notification
 interface NotificationDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertNotifications(vararg notifications: Notification)
+    suspend fun insertNotifications(notifications: Notification)
 
     @Query(
-        "DELETE FROM NOTIFICATION WHERE id = :ids"
+        "DELETE FROM NOTIFICATION WHERE id = :id"
     )
-    suspend fun deleteNotificationsWithIds(vararg ids: String)
+    suspend fun deleteNotificationsWithId(id: String)
 
     @Query(
         "DELETE FROM NOTIFICATION WHERE groupKey = :groupKey"

--- a/domain/src/main/java/com/knocklock/domain/repository/NotificationRepository.kt
+++ b/domain/src/main/java/com/knocklock/domain/repository/NotificationRepository.kt
@@ -12,11 +12,11 @@ interface NotificationRepository {
 
     suspend fun insertGroup(group: Group)
 
-    suspend fun insertNotifications(vararg notifications: Notification)
+    suspend fun insertNotifications(notification: Notification)
 
     fun getGroupWithNotificationsWithSorted(): Flow<List<GroupWithNotification>>
 
-    suspend fun removeNotificationsWithId(vararg ids: String)
+    suspend fun removeNotificationsWithId(id: String)
 
     suspend fun removeGroupWithNotifications(key: String)
 }

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenActivity.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenActivity.kt
@@ -32,10 +32,6 @@ class LockScreenActivity : ComponentActivity() {
 
     private var composeView: ComposeView? = null
 
-    private val manager by lazy {
-        this.applicationContext.packageManager
-    }
-
     private val window by lazy {
         this.applicationContext.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     }
@@ -43,7 +39,6 @@ class LockScreenActivity : ComponentActivity() {
     private val point by lazy { Point() }
     private var notificationListener: LockScreenNotificationListener? = null
     private var mBound: Boolean = false
-    private val vm: LockScreenViewModel by viewModels()
 
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(p0: ComponentName?, service: IBinder) {
@@ -71,8 +66,6 @@ class LockScreenActivity : ComponentActivity() {
                     onRemoveNotifications = { keys ->
                         if (mBound) notificationListener?.cancelNotifications(keys)
                     },
-                    vm = vm,
-                    packageManager = manager,
                 )
             }
             initViewTreeOwner(this)

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenHost.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenHost.kt
@@ -1,6 +1,5 @@
 package com.knocklock.presentation.lockscreen
 
-import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateIntAsState
@@ -17,6 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.android.renderscript.Toolkit
 import com.knocklock.domain.model.AuthenticationType
 import com.knocklock.presentation.R
@@ -33,10 +34,10 @@ import com.skydoves.landscapist.glide.GlideImage
 fun LockScreenHost(
     modifier: Modifier = Modifier,
     onFinish: () -> Unit,
-    vm: LockScreenViewModel,
+    vm: LockScreenViewModel = hiltViewModel(),
     onRemoveNotifications: (Array<String>) -> Unit,
-    packageManager: PackageManager,
 ) {
+    val packageManager = LocalContext.current.packageManager
     LaunchedEffect(key1 = Unit) {
         vm.getGroupNotifications(packageManager)
     }

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/mapper/NotificationMapper.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/mapper/NotificationMapper.kt
@@ -17,19 +17,16 @@ import com.knocklock.domain.model.Notification as NotificationModel
  */
 
 /**
- * StatusBarNotification를 Array<[NotificationModel]>로 변환합니다.
- *
- * StatusBarNotification를 수정할 수 없기 때문에 List->Array로 변환합니다.
- *
+ * StatusBarNotification를 List<[NotificationModel]>로 변환합니다.
  * @param statusBarNotifications Array<out [StatusBarNotification]> activeNotifications 입니다.
- * @return Array<[NotificationModel]>
+ * @return List<[NotificationModel]>
  */
-fun toModel(statusBarNotifications: Array<out StatusBarNotification>, packageManager: PackageManager): Array<NotificationModel> {
+fun mapToList(statusBarNotifications: Array<out StatusBarNotification>, packageManager: PackageManager) : List<NotificationModel>{
     return statusBarNotifications.asSequence().filter { statusBarNotification ->
         statusBarNotification.isNotEmptyTitleOrContent()
     }.map { statusBarNotification ->
         statusBarNotification.toModel(packageManager)
-    }.toList().toTypedArray()
+    }.toList()
 }
 
 /**


### PR DESCRIPTION
## 🔥 관련 이슈

x

## 🔥 PR Point
- vararg 가변인자를 쓰면 코드가 더 깔끔하긴한데, suspend function을 병렬적으로 처리할 수 없는 것 같아서 for loop내부에서 launch{}를 통해 병렬적으로 저장하도록 변경하였습니다.
- for loop launch{}와 같은 방법은 vararg보다 빠를 수 있지만, launch{}를 많이 생성하기 때문에, 더많은 리소스를 사용할 수 있다고 하지만, activeNotification의 갯수가 많지 않다는 가정하에 작성하엿습니다.

