### PR TITLE
Feature/add item animation

### DIFF
--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenHost.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenHost.kt
@@ -69,7 +69,6 @@ fun LockScreenHost(
             exit = fadeOut(),
         ) {
             LockScreenRoute(
-                modifier = Modifier,
                 notificationUiState = notificationUiState,
                 notificationUiFlagState = notificationUiFlagState.toImmutableMap(),
                 userSwipe = {

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenHost.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenHost.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asAndroidBitmap
@@ -98,7 +97,8 @@ fun LockScreenHost(
                         }
                     }
                 },
-                updateNotificationExpandableFlag = vm::updateExpandable
+                updateNotificationExpandableFlag = vm::updateExpandable,
+                updateNotificationClickableFlag = vm::updateClickable,
             )
         }
 

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenNotiItem.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenNotiItem.kt
@@ -4,7 +4,6 @@ import android.app.PendingIntent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandLess
@@ -15,9 +14,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -39,13 +35,13 @@ import kotlinx.collections.immutable.ImmutableList
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SwipeToDismissLockNotiItem(
-    modifier: Modifier = Modifier,
     onNotificationClicked: (PendingIntent) -> Unit,
     onRemoveNotification: (List<String>) -> Unit,
     notification: Notification,
-    notificationSize: Int,
     clickableState: Boolean,
     expandableState: Boolean,
+    modifier: Modifier = Modifier,
+    updateSwipeOffset: (Float) -> Unit,
     groupNotification: ImmutableList<Notification>? = null,
 ) {
     val updateGroupNotification by rememberUpdatedState(newValue = groupNotification)
@@ -79,6 +75,12 @@ fun SwipeToDismissLockNotiItem(
             false
         }
     })
+
+    LaunchedEffect(dismissState) {
+        snapshotFlow { dismissState.offset.value }.collect {
+            updateSwipeOffset(it)
+        }
+    }
     SwipeToDismiss(
         modifier = modifier,
         state = dismissState,
@@ -95,7 +97,6 @@ fun SwipeToDismissLockNotiItem(
         background = {},
     )
 }
-
 
 @Composable
 fun LockNotiItem(

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenNotiItem.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenNotiItem.kt
@@ -1,7 +1,6 @@
 package com.knocklock.presentation.lockscreen
 
 import android.app.PendingIntent
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -81,101 +80,60 @@ fun SwipeToDismissLockNotiItem(
         }
     })
     SwipeToDismiss(
+        modifier = modifier,
         state = dismissState,
         dismissThresholds = { FractionalThreshold(0.25f) },
         dismissContent = {
-            Column {
-                Box {
-                    LockNotiItem(
-                        modifier = modifier,
-                        notification = updateNotification,
-                    )
-                    if (clickableState) {
-                        Icon(
-                            modifier = Modifier
-                                .align(Alignment.CenterEnd)
-                                .padding(end = 5.dp),
-                            imageVector = if (expandableState) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
-                            contentDescription = null,
-                        )
-                    }
-                }
-                AnimatedVisibility(visible = !expandableState) {
-                    Column {
-                        if (notificationSize == 2) {
-                            MoreNotification(
-                                modifier = Modifier
-                                    .padding(horizontal = 15.dp)
-                                    .fillMaxWidth()
-                                    .height(7.dp),
-                            )
-                        } else if (notificationSize >= 3) {
-                            MoreNotification(
-                                modifier = Modifier
-                                    .padding(horizontal = 15.dp)
-                                    .fillMaxWidth()
-                                    .height(7.dp),
-                            )
-                            MoreNotification(
-                                modifier = Modifier
-                                    .padding(horizontal = 35.dp)
-                                    .fillMaxWidth()
-                                    .height(5.dp),
-                            )
-                        }
-                    }
-                }
+            Box {
+                LockNotiItem(
+                    notification = updateNotification,
+                    clickableState = clickableState,
+                    expandableState = expandableState,
+                )
             }
         },
         background = {},
     )
 }
 
-@Composable
-fun MoreNotification(
-    modifier: Modifier = Modifier,
-) {
-    val moreNotificationShape = RoundedCornerShape(bottomStart = 5.dp, bottomEnd = 5.dp)
-    Row(
-        modifier = modifier
-            .background(
-                brush = Brush.verticalGradient(
-                    listOf(
-                        Color(0xFFFAFAFA).copy(alpha = 0.9f),
-                        Color.LightGray,
-                    ),
-                ),
-                shape = moreNotificationShape,
-            )
-            .clip(shape = moreNotificationShape),
-    ) {}
-}
 
 @Composable
 fun LockNotiItem(
     modifier: Modifier = Modifier,
     notification: Notification,
+    clickableState: Boolean,
+    expandableState: Boolean,
 ) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        LockNotiTop(
-            modifier = Modifier
-                .padding(horizontal = 10.dp)
-                .padding(top = 4.dp),
-            packageName = notification.packageName,
-            appTitle = notification.appTitle,
-            time = notification.notiTime,
-        )
-        LockNotiContent(
-            modifier = Modifier
-                .padding(horizontal = 10.dp)
-                .padding(bottom = 4.dp)
-                .wrapContentHeight(),
-            title = notification.title,
-            content = notification.content,
-        )
+    Box(modifier = modifier) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            LockNotiTop(
+                modifier = Modifier
+                    .padding(horizontal = 10.dp)
+                    .padding(top = 4.dp),
+                packageName = notification.packageName,
+                appTitle = notification.appTitle,
+                time = notification.notiTime,
+            )
+            LockNotiContent(
+                modifier = Modifier
+                    .padding(horizontal = 10.dp)
+                    .padding(bottom = 4.dp)
+                    .wrapContentHeight(),
+                title = notification.title,
+                content = notification.content,
+            )
+        }
+        if (clickableState) {
+            Icon(
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = 5.dp),
+                imageVector = if (expandableState) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+                contentDescription = null,
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenViewModel.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenViewModel.kt
@@ -104,6 +104,15 @@ class LockScreenViewModel @Inject constructor(
             }
         }
     }
+    fun updateClickable(key: String, state: Boolean) = with(_notificationUiFlagStateState.value) {
+        if (this.containsKey(key).not()) {
+            this[key] = NotificationUiFlagState()
+        } else {
+            this[key]?.let { uiFlag ->
+                this[key] = uiFlag.copy(clickable = state)
+            }
+        }
+    }
 }
 
 sealed class ComposeScreenState {


### PR DESCRIPTION
## 🔥 관련 이슈

close #128 

## 🔥 PR Point
- LazyColumn 아이템 Animation추가 


## 🔥 동작 순서
Screen 세로 길이의 0.7f에 해당하는 threshold에 도달할때까지, 투명한 Canvas가 보이도록하고
해당 threshold의 위로 Canvas가 지나가게 된다면 
배경, scale , alpha 변경 

좌우 swipe시 해당 canvas의 translateX에 offset 전달

## 📷 Screenshot

https://user-images.githubusercontent.com/62296097/236597795-d72bd2ab-5d1a-4df1-a2f8-10e68b37e070.mp4


