### PR TITLE
Systembar 동작시 focus 잃어버리는 버그 해결 & recents  home button 동작 막기 추가

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.REORDER_TASKS" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.EXPAND_STATUS_BAR"/>
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenActivity.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenActivity.kt
@@ -1,5 +1,6 @@
 package com.knocklock.presentation.lockscreen
 
+import android.app.ActivityManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -16,10 +17,14 @@ import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.setViewTreeOnBackPressedDispatcherOwner
 import androidx.activity.viewModels
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.compositionContext
 import androidx.compose.ui.platform.createLifecycleAwareWindowRecomposer
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
@@ -28,8 +33,16 @@ import com.knocklock.presentation.lockscreen.model.RemovedType.Old
 import com.knocklock.presentation.lockscreen.model.RemovedType.Recent
 import com.knocklock.presentation.lockscreen.receiver.NotificationPostedListener
 import com.knocklock.presentation.lockscreen.receiver.NotificationPostedReceiver
+import com.knocklock.presentation.lockscreen.receiver.OnSystemBarEventListener
+import com.knocklock.presentation.lockscreen.receiver.SystemBarEventReceiver
 import com.knocklock.presentation.lockscreen.service.LockScreenNotificationListener
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import com.knocklock.domain.model.Notification as NotificationModel
@@ -43,6 +56,9 @@ class LockScreenActivity : ComponentActivity() {
         this.applicationContext.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     }
 
+    private val activityManager by lazy {
+        this.applicationContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+    }
     private val lockScreenViewModel: LockScreenViewModel by viewModels()
 
     private val notificationPostedReceiver by lazy {
@@ -56,6 +72,22 @@ class LockScreenActivity : ComponentActivity() {
                 }
             },
 
+        )
+    }
+
+    private val _systembarEvent = MutableSharedFlow<Unit>()
+    private val sendSystemEventJob = Job()
+    private val scope = CoroutineScope(sendSystemEventJob + Dispatchers.Default)
+    private val systemBarEventReceiver by lazy {
+        SystemBarEventReceiver(
+            context = this,
+            onSystemBarEventListener = object : OnSystemBarEventListener {
+                override fun onSystemBarClicked() {
+                    scope.launch {
+                        _systembarEvent.emit(Unit)
+                    }
+                }
+            },
         )
     }
 
@@ -79,11 +111,21 @@ class LockScreenActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         getWindowSize()
         registerNotificationPostedReceiver()
+        registerSystemBarEventReceiver()
         composeView = ComposeView(this).apply {
             val parent = this.compositionContext
             setParentCompositionContext(parent)
 
             setContent {
+                val lifecycle = LocalLifecycleOwner.current.lifecycle
+                LaunchedEffect(key1 = Unit) {
+                    lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                        _systembarEvent.collectLatest {
+                            startActivity(intent)
+                        }
+                    }
+                }
+
                 LockScreenHost(
                     onFinish = {
                         lockScreenViewModel.saveRecentNotificationToDatabase()
@@ -114,6 +156,10 @@ class LockScreenActivity : ComponentActivity() {
         }
     }
 
+    override fun onPause() {
+        super.onPause()
+        activityManager.moveTaskToFront(taskId, 0)
+    }
     override fun onStop() {
         super.onStop()
         unbindService(connection)
@@ -123,6 +169,7 @@ class LockScreenActivity : ComponentActivity() {
     override fun onDestroy() {
         super.onDestroy()
         unregisterNotificationPostedReceiver()
+        unregisterSystemBarEventReceiver()
         window.removeViewImmediate(composeView)
         notificationListener = null
         composeView = null
@@ -202,5 +249,12 @@ class LockScreenActivity : ComponentActivity() {
     }
     private fun unregisterNotificationPostedReceiver() {
         notificationPostedReceiver.unregisterReceiver()
+    }
+    private fun registerSystemBarEventReceiver() {
+        systemBarEventReceiver.registerReceiver()
+    }
+
+    private fun unregisterSystemBarEventReceiver() {
+        systemBarEventReceiver.unregisterReceiver()
     }
 }

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/service/LockScreenNotificationListener.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/service/LockScreenNotificationListener.kt
@@ -25,9 +25,7 @@ import com.knocklock.presentation.lockscreen.mapper.toModel
 import com.knocklock.presentation.lockscreen.receiver.NotificationPostedReceiver.Companion.PostedAction
 import com.knocklock.presentation.lockscreen.receiver.NotificationPostedReceiver.Companion.PostedNotification
 import com.knocklock.presentation.lockscreen.receiver.OnScreenEventListener
-import com.knocklock.presentation.lockscreen.receiver.OnSystemBarEventListener
 import com.knocklock.presentation.lockscreen.receiver.ScreenEventReceiver
-import com.knocklock.presentation.lockscreen.receiver.SystemBarEventReceiver
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -88,17 +86,6 @@ class LockScreenNotificationListener :
         )
     }
 
-    private val systemBarEventReceiver by lazy {
-        SystemBarEventReceiver(
-            context = this,
-            onSystemBarEventListener = object : OnSystemBarEventListener {
-                override fun onSystemBarClicked() {
-                    // Todo 현재 PassWordScreen이 열려있는지
-                }
-            },
-        )
-    }
-
     override fun onNotificationPosted(sbn: StatusBarNotification?) {
         super.onNotificationPosted(sbn)
         val packageName = sbn?.packageName
@@ -118,7 +105,6 @@ class LockScreenNotificationListener :
 
     override fun onCreate() {
         super.onCreate()
-        registerSystemBarEventReceiver()
         registerScreenEventReceiver()
         collectFlow()
     }
@@ -178,7 +164,6 @@ class LockScreenNotificationListener :
 
     override fun onDestroy() {
         super.onDestroy()
-        unregisterSystemBarEventReceiver()
         unregisterScreenEventReceiver()
         job.cancel()
     }
@@ -212,13 +197,7 @@ class LockScreenNotificationListener :
             .build()
     }
 
-    private fun registerSystemBarEventReceiver() {
-        systemBarEventReceiver.registerReceiver()
-    }
 
-    private fun unregisterSystemBarEventReceiver() {
-        systemBarEventReceiver.unregisterReceiver()
-    }
 
     private fun registerScreenEventReceiver() {
         screenEventReceiver.registerReceiver()


### PR DESCRIPTION
## 🔥 관련 이슈

close #140 

## 🔥 PR Point
- 가끔식 잠금화면이 되지 않고 애니메이션이 멈추는 버그를 해결하였습니다.
- System navigationBar가 동작을 가져가면서 focus를 잃게 되어 발생한 문제였습니다.
- 시스템바 버튼 동작시 onPause() -> onStop()으로 Lifecycle이 이동하는데 , onPause상태에서 activityManager를 통해 최상위로 LockScreen이 오도록하여 focus를 다시 가지도록 변경하였습니다.
- Systembar Event중 recent와 home button을 길게 swipe했을 경우, 잠금 해제후  recents app screen이 보이게 되는데, 
systembar Event가 발생했을 때 잠금화면을 다시한번 시작하면 해당 동작을 하지 않더라구요 ... 몇주 삽질하다가 방금알게 되었는데 제 테스트 기기에서는 해결이 되었는데 타 기기에서도 테스트가 필요해 보입니다


## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|Home & Recent Button Event Prevent|https://github.com/Knock-Lock/Knock-Lock/assets/62296097/b65a58c0-4ee1-40b0-8fa1-0603e43f6e65|








