### PR TITLE
ViewModel Logic을 NotificationListenerService로 이동

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
     <application>
         <activity
             android:name=".lockscreen.LockScreenActivity"
-            android:launchMode="singleTask"
+            android:launchMode="singleTop"
             android:exported="false">
             <meta-data
                 android:name="android.app.lib_name"

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenActivity.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenActivity.kt
@@ -18,6 +18,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.setViewTreeOnBackPressedDispatcherOwner
 import androidx.activity.viewModels
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -133,7 +134,7 @@ class LockScreenActivity : ComponentActivity() {
                         val copyList = lockScreenViewModel.recentNotificationList.value.map {
                             it.copy()
                         }
-                        lockScreenViewModel.clearRecentNotificationList()
+                        lockScreenViewModel.updateCollect()
                         notificationListener?.saveRecentNotificationToDatabase(copyList)
                         this@LockScreenActivity.finish()
                     },

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenActivity.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenActivity.kt
@@ -121,7 +121,9 @@ class LockScreenActivity : ComponentActivity() {
                 LaunchedEffect(key1 = Unit) {
                     lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                         _systembarEvent.collectLatest {
-                            startActivity(intent)
+                            startActivity(
+                                Intent(this@LockScreenActivity, LockScreenActivity::class.java),
+                            )
                         }
                     }
                 }
@@ -179,7 +181,6 @@ class LockScreenActivity : ComponentActivity() {
         }
         unregisterNotificationPostedReceiver()
         unregisterSystemBarEventReceiver()
-        window.removeViewImmediate(composeView)
         notificationListener = null
         composeView = null
     }

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenViewModel.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenViewModel.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.util.Stack
 import javax.inject.Inject
 import com.knocklock.domain.model.Notification as NotificationModel
 
@@ -168,26 +167,10 @@ class LockScreenViewModel @Inject constructor(
             }
         }
     }
-
-    fun saveRecentNotificationToDatabase() {
+    fun clearRecentNotificationList() {
         viewModelScope.launch {
-            val stack = Stack<GroupWithNotification>()
-            _recentNotificationList.value.forEach {
-                stack.add(it)
-            }
-            while (stack.isNotEmpty()) {
-                val groupWithNotificationStack = stack.pop()
-                _recentNotificationList.update {
-                    stack.toList()
-                }
-                notificationRepository.insertGroup(
-                    groupWithNotificationStack.toModel().group,
-                )
-                notificationRepository.insertNotifications(
-                    *groupWithNotificationStack.notifications.map { notification ->
-                        notification.toModel()
-                    }.toTypedArray(),
-                )
+            _recentNotificationList.update {
+                emptyList()
             }
         }
     }
@@ -307,7 +290,6 @@ class LockScreenViewModel @Inject constructor(
         }
     }
     fun updateClickable(key: String, state: Boolean) {
-
 //        with(_notificationUiFlagStateState.value) {
 //        if (this.containsKey(key).not()) {
 //            this[key] = NotificationUiFlagState()

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/service/LockScreenNotificationListener.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/service/LockScreenNotificationListener.kt
@@ -22,6 +22,7 @@ import com.knocklock.presentation.MainActivity
 import com.knocklock.presentation.lockscreen.LockScreenActivity
 import com.knocklock.presentation.lockscreen.mapper.isNotEmptyTitleOrContent
 import com.knocklock.presentation.lockscreen.mapper.toModel
+import com.knocklock.presentation.lockscreen.model.GroupWithNotification
 import com.knocklock.presentation.lockscreen.receiver.NotificationPostedReceiver.Companion.PostedAction
 import com.knocklock.presentation.lockscreen.receiver.NotificationPostedReceiver.Companion.PostedNotification
 import com.knocklock.presentation.lockscreen.receiver.OnScreenEventListener
@@ -36,6 +37,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import java.util.Stack
 import javax.inject.Inject
 
 /**
@@ -65,6 +67,8 @@ class LockScreenNotificationListener :
     inner class LocalBinder : Binder() {
         fun getService(): LockScreenNotificationListener = this@LockScreenNotificationListener
     }
+
+    private val recentNotifications = MutableStateFlow(arrayListOf<GroupWithNotification>())
 
     override fun onBind(intent: Intent): IBinder? {
         val action = intent.action
@@ -116,6 +120,28 @@ class LockScreenNotificationListener :
         }
     }
 
+    fun saveRecentNotificationToDatabase(
+        recentNotificationList: List<GroupWithNotification>,
+    ) {
+        notificationScope.launch {
+            val stack = Stack<GroupWithNotification>()
+            recentNotificationList.forEach {
+                stack.add(it)
+            }
+            while (stack.isNotEmpty()) {
+                val groupWithNotificationStack = stack.pop()
+                notificationRepository.insertGroup(
+                    groupWithNotificationStack.toModel().group,
+                )
+                notificationRepository.insertNotifications(
+                    *groupWithNotificationStack.notifications.map { notification ->
+                        notification.toModel()
+                    }.toTypedArray(),
+                )
+            }
+        }
+    }
+
     override fun onCreate() {
         super.onCreate()
         registerSystemBarEventReceiver()
@@ -139,7 +165,7 @@ class LockScreenNotificationListener :
         initNotificationsToLockScreen()
         try {
             val intent = Intent(this, LockScreenActivity::class.java).apply {
-                flags = (Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
+                flags = (Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS or Intent.FLAG_ACTIVITY_NO_ANIMATION)
             }
             startActivity(intent)
         } catch (e: IllegalStateException) {


### PR DESCRIPTION
## 🔥 관련 이슈

close #147 

## 🔥 PR Point
- viewModel 로직을 service로 이동하였습니다.
- clearRecentNotification이 없다면 LazyColumn에서 중복키로 인한 오류가 발생해서 추가했습니다.
- 최대한 자연스럽게 만들려고 노력했는데 코드는 혼란스럽게 짜버렸네요 .. 리팩터링이 필요합니다.
## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|자연스럽게 노티 저장 및 액티비티 종료 |https://github.com/Knock-Lock/Knock-Lock/assets/62296097/e849bda1-83f8-40ad-9c4c-bc99f28be85e|






