### PR TITLE
Home에서 Spacer를 LockNotiItem으로 대체

### DIFF
--- a/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/home/HomeScreen.kt
@@ -17,6 +17,8 @@ import com.knocklock.domain.model.LockScreen
 import com.knocklock.domain.model.LockScreenBackground
 import com.knocklock.presentation.home.menu.HomeMenu
 import com.knocklock.presentation.home.menu.HomeMenuBar
+import com.knocklock.presentation.lockscreen.LockNotiItem
+import com.knocklock.presentation.lockscreen.model.Notification
 import com.knocklock.presentation.ui.theme.KnockLockTheme
 import com.knocklock.presentation.widget.ClockWidget
 import kotlinx.collections.immutable.toImmutableList
@@ -25,7 +27,7 @@ import kotlinx.collections.immutable.toImmutableList
 fun HomeScreen(
     modifier: Modifier = Modifier,
     homeScreenUiState: HomeScreenUiState,
-    onClickHomeMenu: (HomeMenu) -> Unit
+    onClickHomeMenu: (HomeMenu) -> Unit,
 ) {
     Box(modifier = modifier.navigationBarsPadding()) {
         if (homeScreenUiState is HomeScreenUiState.Success) {
@@ -36,11 +38,11 @@ fun HomeScreen(
                     .align(Alignment.TopEnd)
                     .zIndex(1f),
                 menuList = homeScreenUiState.menuList,
-                onClickHomeMenu = onClickHomeMenu
+                onClickHomeMenu = onClickHomeMenu,
             )
             HomeContent(
                 modifier = Modifier.fillMaxSize(),
-                homeScreenUiState = homeScreenUiState
+                homeScreenUiState = homeScreenUiState,
             )
         }
     }
@@ -55,24 +57,24 @@ fun HomeContent(
         HomeBackground(
             scale = homePreviewScale,
             modifier = modifier,
-            lockScreenBackground = homeScreenUiState.lockScreen.background
+            lockScreenBackground = homeScreenUiState.lockScreen.background,
         )
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .scale(homePreviewScale)
+                .scale(homePreviewScale),
         ) {
             ClockWidget(
                 modifier = Modifier
                     .scale(homePreviewScale)
                     .padding(top = 80.dp)
                     .align(CenterHorizontally),
-                timeFormat = homeScreenUiState.lockScreen.timeFormat
+                timeFormat = homeScreenUiState.lockScreen.timeFormat,
             )
             HomeSampleNotifications(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 24.dp)
+                    .padding(top = 24.dp),
             )
         }
     }
@@ -80,21 +82,22 @@ fun HomeContent(
 
 @Composable
 fun HomeSampleNotifications(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier.padding(horizontal = 24.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         (0..4).forEach { _ ->
-            Spacer(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(48.dp)
+            LockNotiItem(
+                modifier = Modifier.fillMaxWidth()
                     .background(
-                        color = Color.Companion.White.copy(alpha = 0.7f),
-                        shape = RoundedCornerShape(10.dp)
+                        color = Color.White.copy(alpha = 0.7f),
+                        shape = RoundedCornerShape(10.dp),
                     ),
+                notification = Notification.default,
+                clickableState = false,
+                expandableState = false,
             )
         }
     }
@@ -109,8 +112,8 @@ private fun HomeContentPrev() {
                 modifier = Modifier.fillMaxSize(),
                 homeScreenUiState = HomeScreenUiState.Success(
                     lockScreen = LockScreen(LockScreenBackground.DefaultWallPaper),
-                    menuList = emptyList<HomeMenu>().toImmutableList()
-                )
+                    menuList = emptyList<HomeMenu>().toImmutableList(),
+                ),
             )
         }
     }

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/model/Notification.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/model/Notification.kt
@@ -21,7 +21,20 @@ data class Notification(
     val isClearable: Boolean = false,
     val intent: PendingIntent? = null,
     val packageName: String? = null,
-)
+) {
+    companion object {
+        val default = Notification(
+            groupKey = "",
+            id = "",
+            appTitle = "낙낙",
+            postedTime = System.currentTimeMillis(),
+            notiTime = "",
+            title = "Sample",
+            content = "Sample Text",
+            isClearable = false,
+        )
+    }
+}
 
 data class RemovedGroupNotification(
     val key: String,


### PR DESCRIPTION
## 🔥 관련 이슈

close #150 

## 🔥 PR Point
- 기존의 spacer를 LockNotiItem Composable로 대체하였습니다 
- 아직 아이콘은 없어서, 추후에 넣으면 될꺼같아요

## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|컴포저블 대체|![KakaoTalk_Photo_2023-06-15-16-11-57](https://github.com/Knock-Lock/Knock-Lock/assets/62296097/4d7e178f-915f-443b-b04d-a5435c5c75c1)|


