### PR TITLE
전화가 왔을때 뷰 제어 

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
     <application>
         <activity
             android:name=".lockscreen.LockScreenActivity"

--- a/presentation/src/main/java/com/knocklock/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/MainActivity.kt
@@ -33,7 +33,7 @@ class MainActivity : ComponentActivity() {
                 val navController = rememberNavController()
                 KnockLockNavHost(
                     modifier = Modifier.fillMaxSize(),
-                    navController = navController
+                    navController = navController,
                 )
             }
         }
@@ -57,7 +57,8 @@ class MainActivity : ComponentActivity() {
                 .setDeniedMessage("잠금 화면 스크린 사용을 위한 권한을 허용해주세요")
                 .setPermissions(
                     Manifest.permission.FOREGROUND_SERVICE,
-                    Manifest.permission.SYSTEM_ALERT_WINDOW
+                    Manifest.permission.SYSTEM_ALERT_WINDOW,
+                    Manifest.permission.READ_PHONE_STATE,
                 ).check()
         } else {
             TedPermission.create()
@@ -75,7 +76,8 @@ class MainActivity : ComponentActivity() {
                 })
                 .setDeniedMessage("권한을 허용해주세요")
                 .setPermissions(
-                    Manifest.permission.SYSTEM_ALERT_WINDOW
+                    Manifest.permission.SYSTEM_ALERT_WINDOW,
+                    Manifest.permission.READ_PHONE_STATE,
                 ).check()
         }
     }
@@ -85,7 +87,7 @@ class MainActivity : ComponentActivity() {
         val sets: Set<String> = NotificationManagerCompat.getEnabledListenerPackages(this)
         if (!sets.contains(packageName)) {
             val intent = Intent(
-                Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS
+                Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS,
             )
             startActivity(intent)
         }

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenActivity.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenActivity.kt
@@ -11,6 +11,7 @@ import android.graphics.Point
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
+import android.os.PowerManager
 import android.view.Gravity
 import android.view.View
 import android.view.WindowManager
@@ -18,7 +19,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.setViewTreeOnBackPressedDispatcherOwner
 import androidx.activity.viewModels
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -32,9 +32,12 @@ import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.knocklock.presentation.lockscreen.model.RemovedGroupNotification
 import com.knocklock.presentation.lockscreen.model.RemovedType.Old
 import com.knocklock.presentation.lockscreen.model.RemovedType.Recent
+import com.knocklock.presentation.lockscreen.receiver.CallState
+import com.knocklock.presentation.lockscreen.receiver.CallStateCallBack
 import com.knocklock.presentation.lockscreen.receiver.NotificationPostedListener
 import com.knocklock.presentation.lockscreen.receiver.NotificationPostedReceiver
 import com.knocklock.presentation.lockscreen.receiver.OnSystemBarEventListener
+import com.knocklock.presentation.lockscreen.receiver.PhoneCallStateReceiver
 import com.knocklock.presentation.lockscreen.receiver.SystemBarEventReceiver
 import com.knocklock.presentation.lockscreen.service.LockScreenNotificationListener
 import dagger.hilt.android.AndroidEntryPoint
@@ -51,7 +54,9 @@ import com.knocklock.domain.model.Notification as NotificationModel
 @AndroidEntryPoint
 class LockScreenActivity : ComponentActivity() {
 
-    private var composeView: ComposeView? = null
+    private val composeView: ComposeView by lazy {
+        setComposeView()
+    }
 
     private val window by lazy {
         this.applicationContext.getSystemService(Context.WINDOW_SERVICE) as WindowManager
@@ -73,6 +78,37 @@ class LockScreenActivity : ComponentActivity() {
                 }
             },
 
+        )
+    }
+
+    private val pm by lazy { getSystemService(POWER_SERVICE) as PowerManager }
+
+    private val phoneCallStateReceiver by lazy {
+        PhoneCallStateReceiver(
+            context = this,
+            callStateCallBack = object : CallStateCallBack {
+                override fun onReceiveCallState(callState: CallState) {
+                    when (callState) {
+                        CallState.IDLE -> {
+                            val intent = Intent(this@LockScreenActivity, LockScreenActivity::class.java).apply {
+                                flags = (Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS or Intent.FLAG_ACTIVITY_NO_ANIMATION)
+                            }
+                            startActivity(intent)
+                        }
+                        CallState.RINGING -> {
+                            if (!pm.isInteractive) {
+                                composeView.let {
+                                    removeViewTreeOwner(it)
+                                    windowManager.removeViewImmediate(it)
+                                }
+                            }
+                        }
+
+                        CallState.OFFHOOK -> {
+                        }
+                    }
+                }
+            },
         )
     }
 
@@ -111,9 +147,12 @@ class LockScreenActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         getWindowSize()
-        registerNotificationPostedReceiver()
-        registerSystemBarEventReceiver()
-        composeView = ComposeView(this).apply {
+        registerReceiver()
+        window.addView(composeView, getWindowManagerLayoutParams())
+    }
+
+    private fun setComposeView(): ComposeView {
+        return ComposeView(this).apply {
             val parent = this.compositionContext
             setParentCompositionContext(parent)
 
@@ -153,7 +192,6 @@ class LockScreenActivity : ComponentActivity() {
             }
             initViewTreeOwner(this)
         }
-        window.addView(composeView, getWindowManagerLayoutParams())
     }
 
     override fun onStart() {
@@ -176,14 +214,15 @@ class LockScreenActivity : ComponentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        composeView?.let {
-            removeViewTreeOwner(it)
-            windowManager.removeViewImmediate(it)
+        removeViewTreeOwner(composeView)
+        runCatching {
+            windowManager.removeViewImmediate(composeView)
+        }.onFailure {
+            println(it.message)
         }
-        unregisterNotificationPostedReceiver()
-        unregisterSystemBarEventReceiver()
+
+        unregisterReceiver()
         notificationListener = null
-        composeView = null
     }
 
     @OptIn(ExperimentalComposeUiApi::class)
@@ -264,6 +303,16 @@ class LockScreenActivity : ComponentActivity() {
             )
         return params
     }
+    private fun registerReceiver() {
+        registerNotificationPostedReceiver()
+        registerSystemBarEventReceiver()
+        registerPhoneCallStateReceiver()
+    }
+    private fun unregisterReceiver() {
+        unregisterNotificationPostedReceiver()
+        unregisterSystemBarEventReceiver()
+        unregisterPhoneCallStateReceiver()
+    }
     private fun registerNotificationPostedReceiver() {
         notificationPostedReceiver.registerReceiver()
     }
@@ -276,5 +325,13 @@ class LockScreenActivity : ComponentActivity() {
 
     private fun unregisterSystemBarEventReceiver() {
         systemBarEventReceiver.unregisterReceiver()
+    }
+
+    private fun registerPhoneCallStateReceiver() {
+        phoneCallStateReceiver.registerReceiver()
+    }
+
+    private fun unregisterPhoneCallStateReceiver() {
+        phoneCallStateReceiver.unregisterReceiver()
     }
 }

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenActivity.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/LockScreenActivity.kt
@@ -90,10 +90,7 @@ class LockScreenActivity : ComponentActivity() {
                 override fun onReceiveCallState(callState: CallState) {
                     when (callState) {
                         CallState.IDLE -> {
-                            val intent = Intent(this@LockScreenActivity, LockScreenActivity::class.java).apply {
-                                flags = (Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS or Intent.FLAG_ACTIVITY_NO_ANIMATION)
-                            }
-                            startActivity(intent)
+                            this@LockScreenActivity.recreate()
                         }
                         CallState.RINGING -> {
                             if (!pm.isInteractive) {

--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/receiver/PhoneCallStateReceiver.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/receiver/PhoneCallStateReceiver.kt
@@ -1,0 +1,50 @@
+package com.knocklock.presentation.lockscreen.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.telephony.TelephonyManager
+
+/**
+ * @Created by 김현국 2023/06/22
+ */
+class PhoneCallStateReceiver(
+    private val context: Context,
+    private val callStateCallBack: CallStateCallBack,
+) : BroadcastReceiver() {
+    override fun onReceive(p0: Context?, intent: Intent?) {
+        try {
+            val state = intent?.getStringExtra(TelephonyManager.EXTRA_STATE)
+            if (state.equals(TelephonyManager.EXTRA_STATE_RINGING)) {
+                callStateCallBack.onReceiveCallState(CallState.RINGING)
+            }
+            if ((state.equals(TelephonyManager.EXTRA_STATE_OFFHOOK))) {
+                callStateCallBack.onReceiveCallState(CallState.OFFHOOK)
+            }
+            if (state.equals(TelephonyManager.EXTRA_STATE_IDLE)) {
+                callStateCallBack.onReceiveCallState(CallState.IDLE)
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+    fun unregisterReceiver() {
+        context.unregisterReceiver(this)
+    }
+
+    fun registerReceiver() {
+        val filter = IntentFilter().apply {
+            addAction(callIntent)
+        }
+        context.registerReceiver(this, filter)
+    }
+}
+
+interface CallStateCallBack {
+    fun onReceiveCallState(callState: CallState)
+}
+enum class CallState {
+    RINGING, OFFHOOK, IDLE
+}
+const val callIntent = "android.intent.action.PHONE_STATE"


### PR DESCRIPTION
## 🔥 관련 이슈

close #138 

## 🔥 PR Point
- READ_PHONE_STATE permission추가
- PhoneCallStateReceiver 추가 
- 화면이 꺼졋을 때, 통화가 오면 View를 지우고 통화가 끝났을 경우 MainActivity를 재호출
- 화면이 켜져있을때, 통화가 오면 화면이 켜진 상태로 유지, 전화를 끊기 위해서는 상단바에서 제어 
## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|화면이 꺼졌을때 |https://github.com/Knock-Lock/Knock-Lock/assets/62296097/5473771b-1ef6-4243-af01-67cb9f99287a|
|화면이 커졌을 때 | https://github.com/Knock-Lock/Knock-Lock/assets/62296097/5db9a492-e55c-49f4-9f2a-76816ffbeeaa|





