### PR TITLE
[fix] : remove type 매개변수로 전달된것으로 지정

### DIFF
--- a/presentation/src/main/java/com/knocklock/presentation/lockscreen/Notification.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/lockscreen/Notification.kt
@@ -102,7 +102,7 @@ fun LazyItemScope.Notification(
             updateSwipeOffset = {
                 offsetX = it
             },
-            type = RemovedType.Old,
+            type = type,
         )
 
         if (item.notifications.size >= 2 && clickable && !expandable) {


### PR DESCRIPTION
## 🔥 관련 이슈
x

## 🔥 PR Point
- 삭제에 문제가 있었는데, 알고보니 remove type을 전부 Old로 해주고 있는 코드를 발견하여 수정합니다.
