### PR TITLE
feat: 비밀번호 설정 UI 변경

### DIFF
--- a/presentation/src/main/java/com/knocklock/presentation/setting/password/PasswordSettingField.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/setting/password/PasswordSettingField.kt
@@ -1,7 +1,7 @@
 package com.knocklock.presentation.setting.password
 
-import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -10,30 +10,35 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.knocklock.presentation.ui.theme.BrandGreenColor
 import com.knocklock.presentation.ui.theme.KnockLockTheme
 
 @Composable
 fun PasswordSettingField(
     number: String,
+    modifier: Modifier = Modifier
 ) {
-    val circleColor by animateColorAsState(
-        targetValue = if (number.isBlank()) Color.LightGray else BrandGreenColor,
-        label = "PasswordFieldColor"
-    )
     Box(
-        modifier = Modifier
-            .background(
-                color = circleColor,
-                shape = CircleShape
-            )
-            .size(16.dp)
+        modifier = modifier
+            .run {
+                if (number.isBlank()) {
+                    border(
+                        width = 1.dp,
+                        color = Color.Black,
+                        shape = CircleShape
+                    )
+                } else {
+                    background(
+                        color = Color.Black,
+                        shape = CircleShape
+                    )
+                }
+            }
+            .size(20.dp)
     )
 }
 
@@ -45,7 +50,7 @@ fun PasswordSettingFieldLayout(
 ) {
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(16.dp)
+        horizontalArrangement = Arrangement.spacedBy(20.dp)
     ) {
         for (index in 0..maxPasswordLength) {
             val number = password.getOrNull(index)?.toString() ?: ""

--- a/presentation/src/main/java/com/knocklock/presentation/setting/password/PasswordSettingScreen.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/setting/password/PasswordSettingScreen.kt
@@ -1,8 +1,10 @@
 package com.knocklock.presentation.setting.password
 
-import androidx.compose.animation.AnimatedVisibility
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -12,13 +14,19 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.knocklock.presentation.R
 import com.knocklock.presentation.extenstions.wiggle
-import com.knocklock.presentation.ui.component.KnockLockTopAppbar
 import com.knocklock.presentation.ui.theme.KnockLockTheme
+import com.knocklock.presentation.ui.theme.knockLockFontFamily
+import com.knocklock.presentation.ui.theme.labelPrimary
 
 @Composable
 fun PasswordSettingScreen(
@@ -29,53 +37,61 @@ fun PasswordSettingScreen(
     onWiggleAnimationEnd: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(modifier = modifier) {
-        KnockLockTopAppbar(
-            modifier = Modifier.fillMaxWidth(),
-            title = stringResource(R.string.title_password_setting),
-            onBackButtonClick = onBackButtonClick
-        )
-        PasswordSettingContent(
-            modifier = modifier,
-            state = state,
-            onTextButtonClick = onTextButtonClick,
-            onActionClick = onActionClick,
-            onWiggleAnimationEnd = onWiggleAnimationEnd
-        )
-    }
+    BackHandler(onBack = onBackButtonClick)
+
+    PasswordSettingContent(
+        modifier = modifier,
+        state = state,
+        onWiggleAnimationEnd = onWiggleAnimationEnd,
+        onTextButtonClick = onTextButtonClick,
+        onActionClick = onActionClick
+    )
 }
 
 @Composable
 fun PasswordSettingContent(
     state: PasswordInputState,
+    onWiggleAnimationEnd: () -> Unit,
     onTextButtonClick: (String) -> Unit,
     onActionClick: (KeyboardAction) -> Unit,
-    onWiggleAnimationEnd: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.SpaceBetween
     ) {
+        PasswordSettingTitle(
+            modifier = Modifier.fillMaxWidth(),
+            state = state
+        )
         Column(
+            modifier = Modifier.fillMaxWidth().weight(1f),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
+            verticalArrangement = Arrangement.Center
         ) {
-            PasswordSettingTitle(state = state)
+            Text(
+                text = stringResource(state.contentRes),
+                style = TextStyle(
+                    fontSize = 17.sp,
+                    lineHeight = 22.sp,
+                    fontFamily = knockLockFontFamily,
+                    fontWeight = FontWeight(400),
+                    color = labelPrimary
+                )
+            )
             PasswordSettingFieldLayout(
                 modifier = Modifier
                     .wiggle(
                         isWiggle = state.getWigglePassword(),
                         onWiggleAnimationEnded = onWiggleAnimationEnd
                     )
-                    .padding(top = 32.dp),
+                    .padding(top = 43.dp),
                 password = state.inputPassword,
             )
         }
+
         NumberKeyboard(
-            modifier = Modifier
-                .padding(bottom = 24.dp)
-                .padding(horizontal = 24.dp),
+            modifier = Modifier.fillMaxWidth(),
             onTextButtonClick = onTextButtonClick,
             onActionClick = onActionClick
         )
@@ -85,147 +101,95 @@ fun PasswordSettingContent(
 @Composable
 fun PasswordSettingTitle(
     state: PasswordInputState,
-) {
-    when (state) {
-        is PasswordInputState.PasswordNoneState -> {
-            PasswordSettingNoneTitle(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 60.dp)
-            )
-        }
-
-        is PasswordInputState.PasswordConfirmState -> {
-            PasswordSettingConfirmTitle(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 60.dp),
-                state = state
-            )
-        }
-
-        is PasswordInputState.PasswordVerifyState -> {
-            PasswordSettingVerifyTitle(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 60.dp),
-            )
-        }
-    }
-}
-
-@Composable
-fun PasswordSettingNoneTitle(
     modifier: Modifier = Modifier
 ) {
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally
+    Box(
+        modifier = modifier.padding(vertical = 27.dp, horizontal = 16.dp),
     ) {
         Text(
-            style = MaterialTheme.typography.titleMedium,
-            text = stringResource(R.string.desc_password_setting)
-        )
-    }
-}
-
-@Composable
-fun PasswordSettingVerifyTitle(
-    modifier: Modifier = Modifier
-) {
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            style = MaterialTheme.typography.titleMedium,
-            text = stringResource(R.string.desc_password_verify)
-        )
-    }
-}
-
-@Composable
-fun PasswordSettingConfirmTitle(
-    state: PasswordInputState.PasswordConfirmState,
-    modifier: Modifier = Modifier
-) {
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            style = MaterialTheme.typography.titleMedium,
-            text = stringResource(R.string.desc_password_setting_confirm)
-        )
-        AnimatedVisibility(visible = state.isWigglePassword) {
-            Text(
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(top = 16.dp),
-                text = stringResource(R.string.desc_forget_password)
+            modifier = Modifier.align(Alignment.Center),
+            text = stringResource(state.titleRes),
+            style = TextStyle(
+                fontSize = 17.sp,
+                lineHeight = 22.sp,
+                fontFamily = knockLockFontFamily,
+                fontWeight = FontWeight(600),
+                color = labelPrimary
             )
-        }
+        )
+
+        Text(
+            modifier = Modifier.align(Alignment.CenterEnd),
+            text = "취소",
+            style = TextStyle(
+                fontSize = 17.sp,
+                lineHeight = 22.sp,
+                fontFamily = knockLockFontFamily,
+                fontWeight = FontWeight(400),
+                color = Color(0xFF007BFE),
+            )
+        )
     }
 }
 
 
 @Preview("비밀번호 입력 화면")
-
 @Composable
 private fun PasswordSettingScreenPrev() {
     KnockLockTheme {
-        Surface(color = MaterialTheme.colorScheme.primary) {
-            PasswordSettingScreen(
-                modifier = Modifier.fillMaxSize(),
-                state = PasswordInputState.PasswordNoneState(""),
-                onTextButtonClick = {},
-                onActionClick = {},
-                onBackButtonClick = {},
-                onWiggleAnimationEnd = {}
-            )
-        }
+        PasswordSettingScreen(
+            modifier = Modifier.fillMaxSize(),
+            state = PasswordInputState.PasswordNoneState(
+                inputPassword = "",
+                titleRes = R.string.title_password_setting,
+                contentRes = R.string.content_password_setting
+            ),
+            onTextButtonClick = {},
+            onActionClick = {},
+            onBackButtonClick = {},
+            onWiggleAnimationEnd = {}
+        )
     }
 }
 
 @Preview("비밀번호 확인 화면")
-
 @Composable
 private fun PasswordSettingConfirmScreenPrev() {
     KnockLockTheme {
-        Surface(color = MaterialTheme.colorScheme.primary) {
-            PasswordSettingScreen(
-                modifier = Modifier.fillMaxSize(),
-                state = PasswordInputState.PasswordConfirmState(
-                    inputPassword = "",
-                    savedPassword = "",
-                    isWigglePassword = false
-                ),
-                onTextButtonClick = {},
-                onActionClick = {},
-                onBackButtonClick = {},
-                onWiggleAnimationEnd = {}
-            )
-        }
+        PasswordSettingScreen(
+            modifier = Modifier.fillMaxSize(),
+            state = PasswordInputState.PasswordConfirmState(
+                inputPassword = "",
+                savedPassword = "",
+                isWigglePassword = false,
+                titleRes = R.string.title_password_setting,
+                contentRes = R.string.content_password_setting
+            ),
+            onTextButtonClick = {},
+            onActionClick = {},
+            onBackButtonClick = {},
+            onWiggleAnimationEnd = {}
+        )
     }
 }
 
 @Preview("비밀번호 확인 화면 - 실패")
-
 @Composable
 private fun PasswordSettingConfirmFailedScreenPrev() {
     KnockLockTheme {
-        Surface(color = MaterialTheme.colorScheme.primary) {
-            PasswordSettingScreen(
-                modifier = Modifier.fillMaxSize(),
-                state = PasswordInputState.PasswordConfirmState(
-                    inputPassword = "",
-                    savedPassword = "",
-                    isWigglePassword = true
-                ),
-                onTextButtonClick = {},
-                onActionClick = {},
-                onBackButtonClick = {},
-                onWiggleAnimationEnd = {}
-            )
-        }
+        PasswordSettingScreen(
+            modifier = Modifier.fillMaxSize(),
+            state = PasswordInputState.PasswordConfirmState(
+                inputPassword = "",
+                savedPassword = "",
+                isWigglePassword = true,
+                titleRes = R.string.title_password_setting,
+                contentRes = R.string.content_password_setting
+            ),
+            onTextButtonClick = {},
+            onActionClick = {},
+            onBackButtonClick = {},
+            onWiggleAnimationEnd = {}
+        )
     }
 }

--- a/presentation/src/main/java/com/knocklock/presentation/setting/password/PasswordSettingViewModel.kt
+++ b/presentation/src/main/java/com/knocklock/presentation/setting/password/PasswordSettingViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.knocklock.domain.usecase.setting.GetUserUseCase
 import com.knocklock.domain.usecase.setting.UpdatePasswordUseCase
+import com.knocklock.presentation.R
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -22,7 +23,11 @@ class PasswordInputViewModel @Inject constructor(
     getUserUseCase: GetUserUseCase,
 ) : ViewModel() {
     var passwordInputState by mutableStateOf<PasswordInputState>(
-        PasswordInputState.PasswordNoneState("")
+        PasswordInputState.PasswordNoneState(
+            titleRes = R.string.title_password_setting,
+            contentRes = R.string.content_password_setting,
+            inputPassword = ""
+        )
     )
 
     private val userPassword = getUserUseCase()
@@ -41,6 +46,8 @@ class PasswordInputViewModel @Inject constructor(
             userPassword.collect { password ->
                 if (password.isNotBlank()) {
                     passwordInputState = PasswordInputState.PasswordVerifyState(
+                        titleRes = R.string.title_password_change,
+                        contentRes = R.string.content_password_change,
                         inputPassword = "",
                         savedPassword = password
                     )
@@ -124,6 +131,8 @@ class PasswordInputViewModel @Inject constructor(
 
     private fun checkPasswordNoneState(state: PasswordInputState.PasswordNoneState) {
         passwordInputState = PasswordInputState.PasswordConfirmState(
+            titleRes = state.titleRes,
+            contentRes = R.string.content_password_check,
             inputPassword = "",
             savedPassword = state.inputPassword
         )
@@ -131,7 +140,11 @@ class PasswordInputViewModel @Inject constructor(
 
     private fun checkPasswordVerifyState(state: PasswordInputState.PasswordVerifyState) {
         passwordInputState = if (state.inputPassword == state.savedPassword) {
-            PasswordInputState.PasswordNoneState("")
+            PasswordInputState.PasswordNoneState(
+                titleRes = state.titleRes,
+                contentRes = R.string.content_password_change,
+                inputPassword = ""
+            )
         } else {
             state.copy(
                 inputPassword = "",
@@ -167,7 +180,8 @@ class PasswordInputViewModel @Inject constructor(
             is PasswordInputState.PasswordVerifyState -> {
                 state.copy(isWigglePassword = false)
             }
-            else ->  {
+
+            else -> {
                 state
             }
         }
@@ -175,13 +189,19 @@ class PasswordInputViewModel @Inject constructor(
 }
 
 sealed interface PasswordInputState {
+    val titleRes: Int
+    val contentRes: Int
     val inputPassword: String
 
     data class PasswordNoneState(
+        override val titleRes: Int,
+        override val contentRes: Int,
         override val inputPassword: String
     ) : PasswordInputState
 
     data class PasswordConfirmState(
+        override val titleRes: Int,
+        override val contentRes: Int,
         override val inputPassword: String,
         val savedPassword: String,
         val isWigglePassword: Boolean = false,
@@ -189,6 +209,8 @@ sealed interface PasswordInputState {
     ) : PasswordInputState
 
     data class PasswordVerifyState(
+        override val titleRes: Int,
+        override val contentRes: Int,
         override val inputPassword: String,
         val savedPassword: String,
         val isWigglePassword: Boolean = false,

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -25,10 +25,11 @@
 
     <string name="activate_knocklock">KnockLock 활성화</string>
     <!-- PasswordInput -->
-    <string name="title_password_setting">비밀번호 설정</string>
-    <string name="desc_password_setting">잠금 설정을 위한 비밀번호를 입력하세요.</string>
-    <string name="desc_password_setting_confirm">비밀번호 확인을 위해 다시 입력해주세요.</string>
-    <string name="desc_forget_password">비밀번호를 잊어버리셨다면 뒤로 돌아가주세요.</string>
+    <string name="title_password_setting">암호 설정</string>
+    <string name="title_password_change">암호 변경</string>
+    <string name="content_password_setting">암호 입력</string>
+    <string name="content_password_change">기존 암호 입력</string>
+    <string name="content_password_check">새로운 암호 확인</string>
     <string name="copy_success_msg">후원계좌가 클립보드에 복사되었습니다.\n감사합니다:)</string>
     <string name="copy_failed_msg">계좌복사에 싪패했습니다.</string>
     <string name="desc_password_verify">기존에 설정된 비밀번호를 입력하세요.</string>


### PR DESCRIPTION
## 🔥 PR Point

- 비밀번호 설정 UI 일부 반영
- 암호 해체 시 UI를 디자이너분이 잡아주셨는데 원래 없던 스펙이라서 가져갈 지 논의 필요할 듯
  (개인적으로는 기획 요청이 아닌 디자이너 요청이니 패스해도 괜찮을 듯!)
![image](https://github.com/Knock-Lock/Knock-Lock/assets/33657541/6b060c24-caf0-462a-ae1d-43c5789f450f)
- 키보드 시스템으로 잡아 준 것 같은데.. 텍스트 필드 없이 키보드만으로는 구현하기 어려워보

## 📷 Screenshot
|기능|스크린샷|
|:---|---|
|기능A 구현|![image](https://github.com/Knock-Lock/Knock-Lock/assets/33657541/9f02e409-4219-4e3e-8eea-c3ba71db664e)|
